### PR TITLE
Add package rtt_ros2_rclcpp_typekit which provides a typekit for various rclcpp and  rmw API types

### DIFF
--- a/rtt_ros2/include/orocos/rtt_ros2/getter_setter_datasource.hpp
+++ b/rtt_ros2/include/orocos/rtt_ros2/getter_setter_datasource.hpp
@@ -1,0 +1,181 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2__GETTER_SETTER_DATASOURCE_HPP_
+#define OROCOS__RTT_ROS2__GETTER_SETTER_DATASOURCE_HPP_
+
+#include <map>
+#include <utility>
+
+#include "boost/function.hpp"
+#include "rtt/internal/DataSources.hpp"
+#include "rtt/internal/NA.hpp"
+
+namespace rtt_ros2
+{
+
+/**
+ * A data source which accesses a field of a struct-like object by invoking
+ * the given getter and setter member functions.
+ *
+ * @todo Move to core RTT?
+ */
+template<typename ObjectT, typename FieldT>
+class GetterSetterDataSource : public RTT::internal::AssignableDataSource<FieldT>
+{
+public:
+  using typename RTT::internal::AssignableDataSource<FieldT>::value_t;
+  using typename RTT::internal::AssignableDataSource<FieldT>::result_t;
+  using typename RTT::internal::AssignableDataSource<FieldT>::const_reference_t;
+  using typename RTT::internal::AssignableDataSource<FieldT>::param_t;
+  using typename RTT::internal::AssignableDataSource<FieldT>::reference_t;
+
+  /**
+   * Use this type to store a pointer to a GetterSetterDataSource.
+   */
+  typedef boost::intrusive_ptr<GetterSetterDataSource> shared_ptr;
+  typedef typename boost::intrusive_ptr<const GetterSetterDataSource> const_ptr;
+
+  typedef boost::function<value_t(const ObjectT & obj)> getter_func_t;
+  typedef boost::function<void (ObjectT & obj, param_t value)> setter_func_t;
+
+  /**
+   * Construct a GetterSetterDataSource from an AssignableDataSource of type ObjectT and
+   * functors for getting and setting the value of a specific field of type FieldT, with
+   * a custom default value.
+   */
+  GetterSetterDataSource(
+    typename RTT::internal::AssignableDataSource<ObjectT>::shared_ptr object,
+    getter_func_t getter,
+    setter_func_t setter,
+    param_t default_value = RTT::internal::NA<FieldT>::na())
+  : object_(std::move(object)),
+    getter_(std::move(getter)),
+    setter_(std::move(setter)),
+    value_(std::move(default_value))
+  {}
+
+  ~GetterSetterDataSource()
+  {}
+
+  /**
+   * Return the data as type \a FieldT.
+   */
+  virtual result_t get() const
+  {
+    value_ = getter_(object_->get());
+    return value_;
+  }
+
+  /**
+   * Return the result of the last \a evaluate() function.
+   * You must call evaluate() prior to calling this function in order to get
+   * the most recent value of this attribute.
+   */
+  virtual result_t value() const
+  {
+    return value_;
+  }
+
+  /**
+   * Get a const reference to the value of this DataSource.
+   * You must call evaluate() prior to calling this function in order to get
+   * the most recent value of this attribute.
+   * @note Getting a reference to an internal data structure is not thread-safe.
+   */
+  virtual const_reference_t rvalue() const
+  {
+    return value_;
+  }
+
+  /**
+   * Set this DataSource with a value.
+   */
+  virtual void set(param_t t)
+  {
+    value_ = std::move(t);
+    updated();
+  }
+
+  /**
+   * Get a reference to the value of this DataSource.
+   * Getting a reference to an internal data structure is not thread-safe.
+   */
+  virtual reference_t set()
+  {
+    return value_;
+  }
+
+  virtual bool evaluate() const
+  {
+    if (!object_->evaluate()) {return false;}
+    value_ = getter_(object_->rvalue());
+    return true;
+  }
+
+  /**
+   * In case the internal::DataSource returns a 'reference' type,
+   * call this method to notify it that the data was updated
+   * in the course of an invocation of set().
+   */
+  virtual void updated()
+  {
+    setter_(object_->set(), value_);
+    object_->updated();
+  }
+
+  virtual GetterSetterDataSource * clone() const
+  {
+    return new GetterSetterDataSource(object_, getter_, setter_);
+  }
+
+  virtual GetterSetterDataSource * copy(
+    std::map<
+      const RTT::base::DataSourceBase *,
+      RTT::base::DataSourceBase *> & replace) const
+  {
+    // if somehow a copy exists, return the copy, otherwise return this (see Attribute copy)
+    if (replace[this] != 0) {
+      assert(
+        dynamic_cast<GetterSetterDataSource *>(replace[this]) ==
+        static_cast<GetterSetterDataSource *>(replace[this]));
+      return static_cast<GetterSetterDataSource *>(replace[this]);
+    }
+    typename RTT::internal::AssignableDataSource<ObjectT>::shared_ptr object_copy =
+      RTT::internal::AssignableDataSource<ObjectT>::narrow(object_->copy(replace));
+    replace[this] = new GetterSetterDataSource(object_copy, getter_, setter_);
+    // returns copy
+    return static_cast<GetterSetterDataSource *>(replace[this]);
+  }
+
+  /**
+   * This method narrows a base::DataSourceBase to a typeded AssignableDataSource,
+   * possibly returning a new object.
+   */
+  static GetterSetterDataSource * narrow(RTT::base::DataSourceBase * db)
+  {
+    return dynamic_cast<GetterSetterDataSource>(db);
+  }
+
+protected:
+  typename RTT::internal::AssignableDataSource<ObjectT>::shared_ptr object_;
+  getter_func_t getter_;
+  setter_func_t setter_;
+
+  mutable value_t value_;
+};
+
+}  // namespace rtt_ros2
+
+#endif  // OROCOS__RTT_ROS2__GETTER_SETTER_DATASOURCE_HPP_

--- a/rtt_ros2_builtin_interfaces_typekit/CMakeLists.txt
+++ b/rtt_ros2_builtin_interfaces_typekit/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+project(rtt_ros2_builtin_interfaces_typekit CXX)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#   add_compile_options(-Wall -Wextra -Wpedantic)
+# endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rtt_ros2_idl REQUIRED)
+
+# generate typekit
+rtt_ros2_generate_typekit(builtin_interfaces)
+
+# linters
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# must be called *after* the targets to check exported libraries etc.
+ament_package()
+
+# orocos_generate_package() is deprecated for ROS 2.
+# Prefer cmake target export and import instead, in combination with
+# ament_export_interfaces() or ament_export_targets() when building with
+# ament_cmake.
+orocos_generate_package(
+  DEPENDS_TARGETS rtt_ros2_idl
+)

--- a/rtt_ros2_builtin_interfaces_typekit/package.xml
+++ b/rtt_ros2_builtin_interfaces_typekit/package.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>rtt_ros2_rclcpp_typekit</name>
+  <name>rtt_ros2_builtin_interfaces_typekit</name>
   <version>0.0.0</version>
-  <description>
-    Orocos RTT typekit plugin for rclcpp types
-  </description>
+  <description>RTT typekit and transport plugins for builtin_interfaces</description>
   <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
+  <depend>builtin_interfaces</depend>
   <depend>rtt_ros2</depend>
-  <exec_depend>rtt_ros2_builtin_interfaces_typekit</exec_depend>
-  <exec_depend>rtt_ros2_primitives_typekit</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_builtin_interfaces_typekit/package.xml
+++ b/rtt_ros2_builtin_interfaces_typekit/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>rtt_ros2</depend>
+  <depend>rtt_ros2_idl</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rtt_ros2_idl/src/rtt_ros2_idl/resource/typekit_plugin.cpp.em
+++ b/rtt_ros2_idl/src/rtt_ros2_idl/resource/typekit_plugin.cpp.em
@@ -56,7 +56,7 @@ public:
 
   std::string getName() override
   {
-    static const std::string name = "ros-@(pkg_name)";
+    static const std::string name = "ros2-@(pkg_name)";
     return name;
   }
 };

--- a/rtt_ros2_primitives_typekit/CMakeLists.txt
+++ b/rtt_ros2_primitives_typekit/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2 REQUIRED)
 
 # build ros2-primitives typekit
-orocos_typekit(rtt_ros2_primitives
+orocos_typekit(rtt_ros2_primitives_typekit
   src/typekit/ros2_bool_type.cpp
   src/typekit/ros2_float32_type.cpp
   src/typekit/ros2_float64_type.cpp
@@ -38,7 +38,7 @@ orocos_typekit(rtt_ros2_primitives
   EXPORT ${PROJECT_NAME}
   INCLUDES DESTINATION include/orocos
 )
-target_include_directories(rtt_ros2_primitives
+target_include_directories(rtt_ros2_primitives_typekit
   PRIVATE include/orocos
 )
 

--- a/rtt_ros2_rclcpp_typekit/CMakeLists.txt
+++ b/rtt_ros2_rclcpp_typekit/CMakeLists.txt
@@ -68,6 +68,7 @@ else()
   ament_export_interfaces(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 endif()
 rtt_ros2_export_plugin_depend(rtt_ros2_primitives_typekit)
+rtt_ros2_export_plugin_depend(rtt_ros2_builtin_interfaces_typekit)
 
 # must be called *after* the targets to check exported libraries etc.
 ament_package()

--- a/rtt_ros2_rclcpp_typekit/CMakeLists.txt
+++ b/rtt_ros2_rclcpp_typekit/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.5)
+project(rtt_ros2_rclcpp_typekit)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rtt_ros2 REQUIRED)
+
+# build ros2-primitives typekit
+orocos_typekit(rtt_ros2_rclcpp_typekit
+  src/ros2_node_options_type.cpp
+  src/ros2_parameter_type.cpp
+  src/ros2_parameter_value_type.cpp
+  src/ros2_qos_type.cpp
+  src/rtt_ros2_rclcpp_typekit.cpp
+  EXPORT ${PROJECT_NAME}
+  INCLUDES DESTINATION include/orocos
+)
+target_include_directories(rtt_ros2_rclcpp_typekit
+  PRIVATE include/orocos
+)
+ament_target_dependencies(rtt_ros2_rclcpp_typekit
+  rclcpp
+  rtt_ros2
+)
+
+# install
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+# linters
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# export information to downstream packages
+# ament_export_dependencies(rtt_ros2)
+ament_export_include_directories(include/orocos)
+if(COMMAND ament_export_targets)
+  ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+else()
+  ament_export_interfaces(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+endif()
+rtt_ros2_export_plugin_depend(rtt_ros2_primitives_typekit)
+
+# must be called *after* the targets to check exported libraries etc.
+ament_package()
+
+# orocos_generate_package() is deprecated for ROS 2.
+# Prefer cmake target export and import instead, in combination with
+# ament_export_interfaces() or ament_export_targets() when building with
+# ament_cmake.
+orocos_generate_package(
+  # DEPENDS_TARGETS rtt_ros2
+)

--- a/rtt_ros2_rclcpp_typekit/CMakeLists.txt
+++ b/rtt_ros2_rclcpp_typekit/CMakeLists.txt
@@ -40,6 +40,12 @@ ament_target_dependencies(rtt_ros2_rclcpp_typekit
   rclcpp
   rtt_ros2
 )
+target_compile_definitions(rtt_ros2_rclcpp_typekit
+  PRIVATE
+    rclcpp_VERSION_MAJOR=${rclcpp_VERSION_MAJOR}
+    rclcpp_VERSION_MINOR=${rclcpp_VERSION_MINOR}
+    rclcpp_VERSION_PATCH=${rclcpp_VERSION_PATCH}
+)
 
 # install
 install(

--- a/rtt_ros2_rclcpp_typekit/CMakeLists.txt
+++ b/rtt_ros2_rclcpp_typekit/CMakeLists.txt
@@ -22,10 +22,13 @@ find_package(rtt_ros2 REQUIRED)
 
 # build ros2-primitives typekit
 orocos_typekit(rtt_ros2_rclcpp_typekit
+  src/ros2_duration_type.cpp
   src/ros2_node_options_type.cpp
   src/ros2_parameter_type.cpp
   src/ros2_parameter_value_type.cpp
+  src/ros2_publisher_options_type.cpp
   src/ros2_qos_type.cpp
+  src/ros2_time_type.cpp
   src/rtt_ros2_rclcpp_typekit.cpp
   EXPORT ${PROJECT_NAME}
   INCLUDES DESTINATION include/orocos

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/parameter_value_conversions.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/parameter_value_conversions.hpp
@@ -1,0 +1,174 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__PARAMETER_VALUE_CONVERSIONS_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__PARAMETER_VALUE_CONVERSIONS_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/parameter_value.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+static inline const bool & parameter_value_to_bool(const rclcpp::ParameterValue & t)
+{
+  return t.get<bool>();
+}
+
+static inline rclcpp::ParameterValue bool_to_parameter_value(const bool bool_value)
+{
+  return rclcpp::ParameterValue(bool_value);
+}
+
+static inline int parameter_value_to_int(const rclcpp::ParameterValue & t)
+{
+  return static_cast<int>(t.get<int64_t>());
+}
+
+static inline rclcpp::ParameterValue int_to_parameter_value(const int int_value)
+{
+  return rclcpp::ParameterValue(int_value);
+}
+
+static inline const int64_t & parameter_value_to_int64(const rclcpp::ParameterValue & t)
+{
+  return t.get<int64_t>();
+}
+
+static inline rclcpp::ParameterValue int64_to_parameter_value(const int64_t int_value)
+{
+  return rclcpp::ParameterValue(int_value);
+}
+
+static inline float parameter_value_to_float(const rclcpp::ParameterValue & t)
+{
+  return static_cast<float>(t.get<double>());
+}
+
+static inline rclcpp::ParameterValue float_to_parameter_value(const float float_value)
+{
+  return rclcpp::ParameterValue(float_value);
+}
+
+static inline const double & parameter_value_to_double(const rclcpp::ParameterValue & t)
+{
+  return t.get<double>();
+}
+
+static inline rclcpp::ParameterValue double_to_parameter_value(const double double_value)
+{
+  return rclcpp::ParameterValue(double_value);
+}
+
+static inline const std::string & parameter_value_to_string(const rclcpp::ParameterValue & t)
+{
+  return t.get<std::string>();
+}
+
+static inline rclcpp::ParameterValue string_to_parameter_value(const std::string & string_value)
+{
+  return rclcpp::ParameterValue(string_value);
+}
+
+static inline const std::vector<uint8_t> & parameter_value_to_byte_array(
+  const rclcpp::ParameterValue & t)
+{
+  return t.get<std::vector<uint8_t>>();
+}
+
+static inline rclcpp::ParameterValue byte_array_to_parameter_value(
+  const std::vector<uint8_t> & bye_array_value)
+{
+  return rclcpp::ParameterValue(bye_array_value);
+}
+
+static inline const std::vector<bool> & parameter_value_to_bool_array(
+  const rclcpp::ParameterValue & t)
+{
+  return t.get<std::vector<bool>>();
+}
+
+static inline rclcpp::ParameterValue bool_array_to_parameter_value(
+  const std::vector<bool> & byte_array_value)
+{
+  return rclcpp::ParameterValue(byte_array_value);
+}
+
+static inline const std::vector<int64_t> & parameter_value_to_int64_array(
+  const rclcpp::ParameterValue & t)
+{
+  return t.get<std::vector<int64_t>>();
+}
+
+static inline rclcpp::ParameterValue int64_array_to_parameter_value(
+  const std::vector<int64_t> & int_array_value)
+{
+  return rclcpp::ParameterValue(int_array_value);
+}
+
+static inline std::vector<int> parameter_value_to_int_array(
+  const rclcpp::ParameterValue & t)
+{
+  const auto & int64_array = t.get<std::vector<int64_t>>();
+  return std::vector<int>(int64_array.begin(), int64_array.end());
+}
+
+static inline rclcpp::ParameterValue int_array_to_parameter_value(
+  const std::vector<int> & int_array_value)
+{
+  return rclcpp::ParameterValue(int_array_value);
+}
+
+static inline std::vector<float> parameter_value_to_float_array(
+  const rclcpp::ParameterValue & t)
+{
+  const auto & double_array = t.get<std::vector<double>>();
+  return std::vector<float>(double_array.begin(), double_array.end());
+}
+
+static inline rclcpp::ParameterValue float_array_to_parameter_value(
+  const std::vector<float> & float_array_value)
+{
+  return rclcpp::ParameterValue(float_array_value);
+}
+
+static inline const std::vector<double> & parameter_value_to_double_array(
+  const rclcpp::ParameterValue & t)
+{
+  return t.get<std::vector<double>>();
+}
+
+static inline rclcpp::ParameterValue double_array_to_parameter_value(
+  const std::vector<double> & double_array_value)
+{
+  return rclcpp::ParameterValue(double_array_value);
+}
+
+static inline const std::vector<std::string> & parameter_value_to_string_array(
+  const rclcpp::ParameterValue & t)
+{
+  return t.get<std::vector<std::string>>();
+}
+
+static inline rclcpp::ParameterValue string_array_to_parameter_value(
+  const std::vector<std::string> & string_array_value)
+{
+  return rclcpp::ParameterValue(string_array_value);
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__PARAMETER_VALUE_CONVERSIONS_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/parameter_value_conversions.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/parameter_value_conversions.hpp
@@ -90,9 +90,9 @@ static inline const std::vector<uint8_t> & parameter_value_to_byte_array(
 }
 
 static inline rclcpp::ParameterValue byte_array_to_parameter_value(
-  const std::vector<uint8_t> & bye_array_value)
+  const std::vector<uint8_t> & byte_array_value)
 {
-  return rclcpp::ParameterValue(bye_array_value);
+  return rclcpp::ParameterValue(byte_array_value);
 }
 
 static inline const std::vector<bool> & parameter_value_to_bool_array(

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/rclcpp_version.h
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/rclcpp_version.h
@@ -18,12 +18,12 @@
 /* True if the version of rclcpp is at least major.minor.patch */
 // (from https://github.com/ros2/rmw_cyclonedds/pull/51)
 #define rclcpp_VERSION_GTE(major, minor, patch) ( \
-    major<rclcpp_VERSION_MAJOR ? true \
-    : major> rclcpp_VERSION_MAJOR ? false \
-    : minor<rclcpp_VERSION_MINOR ? true \
-    : minor> rclcpp_VERSION_MINOR ? false \
-    : patch<rclcpp_VERSION_PATCH ? true \
-    : patch> rclcpp_VERSION_PATCH ? false \
+    (major < rclcpp_VERSION_MAJOR) ? true \
+    : (major > rclcpp_VERSION_MAJOR) ? false \
+    : (minor < rclcpp_VERSION_MINOR) ? true \
+    : (minor > rclcpp_VERSION_MINOR) ? false \
+    : (patch < rclcpp_VERSION_PATCH) ? true \
+    : (patch > rclcpp_VERSION_PATCH) ? false \
     : true)
 
 #endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__RCLCPP_VERSION_H_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/rclcpp_version.h
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/rclcpp_version.h
@@ -1,0 +1,29 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__RCLCPP_VERSION_H_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__RCLCPP_VERSION_H_
+
+/* True if the version of rclcpp is at least major.minor.patch */
+// (from https://github.com/ros2/rmw_cyclonedds/pull/51)
+#define rclcpp_VERSION_GTE(major, minor, patch) ( \
+    major<rclcpp_VERSION_MAJOR ? true \
+    : major> rclcpp_VERSION_MAJOR ? false \
+    : minor<rclcpp_VERSION_MINOR ? true \
+    : minor> rclcpp_VERSION_MINOR ? false \
+    : patch<rclcpp_VERSION_PATCH ? true \
+    : patch> rclcpp_VERSION_PATCH ? false \
+    : true)
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__RCLCPP_VERSION_H_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_duration_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_duration_type.hpp
@@ -12,39 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
-#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_DURATION_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_DURATION_TYPE_HPP_
 
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "rclcpp/qos.hpp"
+#include "rclcpp/duration.hpp"
 
-#include "rtt/types/MemberFactory.hpp"
 #include "rtt/types/PrimitiveTypeInfo.hpp"
 
-#include "wrapped_qos.hpp"
+#include "time_io.hpp"
+#include "wrapped_duration.hpp"
 
 namespace rtt_ros2_rclcpp_typekit
 {
 
-class QoSTypeInfo
-  : public RTT::types::PrimitiveTypeInfo<WrappedQoS>,
-  public RTT::types::MemberFactory
+class DurationTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<WrappedDuration, true>
 {
 public:
-  QoSTypeInfo();
+  DurationTypeInfo();
 
   bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
-
-  std::vector<std::string> getMemberNames() const override;
-
-  RTT::base::DataSourceBase::shared_ptr getMember(
-    RTT::base::DataSourceBase::shared_ptr item,
-    const std::string & part_name) const override;
 };
 
 }  // namespace rtt_ros2_rclcpp_typekit
 
-#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_DURATION_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_node_options_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_node_options_type.hpp
@@ -1,0 +1,47 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_NODE_OPTIONS_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_NODE_OPTIONS_TYPE_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/node_options.hpp"
+
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+class NodeOptionsTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<rclcpp::NodeOptions>,
+  public RTT::types::MemberFactory
+{
+public:
+  NodeOptionsTypeInfo();
+
+  bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
+
+  std::vector<std::string> getMemberNames() const override;
+
+  RTT::base::DataSourceBase::shared_ptr getMember(
+    RTT::base::DataSourceBase::shared_ptr item,
+    const std::string & part_name) const override;
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_NODE_OPTIONS_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_parameter_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_parameter_type.hpp
@@ -1,0 +1,48 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PARAMETER_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PARAMETER_TYPE_HPP_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/parameter.hpp"
+
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+class ParameterTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<rclcpp::Parameter>,
+  public RTT::types::MemberFactory
+{
+public:
+  ParameterTypeInfo();
+
+  bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
+
+  std::vector<std::string> getMemberNames() const override;
+
+  RTT::base::DataSourceBase::shared_ptr getMember(
+    RTT::base::DataSourceBase::shared_ptr item,
+    const std::string & part_name) const override;
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PARAMETER_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_parameter_value_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_parameter_value_type.hpp
@@ -1,0 +1,52 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PARAMETER_VALUE_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PARAMETER_VALUE_TYPE_HPP_
+
+#include <iostream>
+#include <string>
+
+#include "rclcpp/parameter_value.hpp"
+
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+class ParameterValueTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<rclcpp::ParameterValue>
+{
+public:
+  ParameterValueTypeInfo();
+
+  bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
+
+  std::ostream & write(
+    std::ostream & os,
+    RTT::base::DataSourceBase::shared_ptr in) const override;
+
+  std::istream & read(
+    std::istream & is,
+    RTT::base::DataSourceBase::shared_ptr out) const override;
+
+  bool isStreamable() const override
+  {
+    return true;
+  }
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PARAMETER_VALUE_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_publisher_options_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_publisher_options_type.hpp
@@ -12,29 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
-#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PUBLISHER_OPTIONS_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PUBLISHER_OPTIONS_TYPE_HPP_
 
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "rclcpp/qos.hpp"
+#include "rclcpp/publisher_options.hpp"
 
 #include "rtt/types/MemberFactory.hpp"
 #include "rtt/types/PrimitiveTypeInfo.hpp"
 
-#include "wrapped_qos.hpp"
-
 namespace rtt_ros2_rclcpp_typekit
 {
 
-class QoSTypeInfo
-  : public RTT::types::PrimitiveTypeInfo<WrappedQoS>,
+class PublisherOptionsBaseTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<rclcpp::PublisherOptionsBase>,
   public RTT::types::MemberFactory
 {
 public:
-  QoSTypeInfo();
+  PublisherOptionsBaseTypeInfo();
 
   bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
 
@@ -47,4 +44,4 @@ public:
 
 }  // namespace rtt_ros2_rclcpp_typekit
 
-#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_PUBLISHER_OPTIONS_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp
@@ -1,0 +1,72 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/qos.hpp"
+
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+// Derived type for RTT, which is default constructible.
+class QoS : public rclcpp::QoS
+{
+public:
+  QoS();
+  explicit QoS(const rclcpp::QoS & qos)
+  : rclcpp::QoS(qos) {}
+  explicit QoS(rclcpp::QoS && qos) noexcept
+  : rclcpp::QoS(std::move(qos)) {}
+  template<typename ... Args>
+  explicit QoS(Args && ... args)
+  : rclcpp::QoS(std::forward<Args>(args)...) {}
+  QoS & operator=(const rclcpp::QoS & qos)
+  {
+    static_cast<rclcpp::QoS &>(*this) = qos;
+    return *this;
+  }
+  QoS & operator=(rclcpp::QoS && qos) noexcept
+  {
+    static_cast<rclcpp::QoS &>(*this) = std::move(qos);
+    return *this;
+  }
+};
+
+class QoSTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<QoS>,
+  public RTT::types::MemberFactory
+{
+public:
+  QoSTypeInfo();
+
+  bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
+
+  std::vector<std::string> getMemberNames() const override;
+
+  RTT::base::DataSourceBase::shared_ptr getMember(
+    RTT::base::DataSourceBase::shared_ptr item,
+    const std::string & part_name) const override;
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_time_type.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/ros2_time_type.hpp
@@ -12,39 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
-#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_TIME_TYPE_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_TIME_TYPE_HPP_
 
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "rclcpp/qos.hpp"
+#include "rclcpp/time.hpp"
 
-#include "rtt/types/MemberFactory.hpp"
 #include "rtt/types/PrimitiveTypeInfo.hpp"
 
-#include "wrapped_qos.hpp"
+#include "time_io.hpp"
 
 namespace rtt_ros2_rclcpp_typekit
 {
 
-class QoSTypeInfo
-  : public RTT::types::PrimitiveTypeInfo<WrappedQoS>,
-  public RTT::types::MemberFactory
+class TimeTypeInfo
+  : public RTT::types::PrimitiveTypeInfo<rclcpp::Time, true>
 {
 public:
-  QoSTypeInfo();
+  TimeTypeInfo();
 
   bool installTypeInfoObject(RTT::types::TypeInfo * ti) override;
-
-  std::vector<std::string> getMemberNames() const override;
-
-  RTT::base::DataSourceBase::shared_ptr getMember(
-    RTT::base::DataSourceBase::shared_ptr item,
-    const std::string & part_name) const override;
 };
 
 }  // namespace rtt_ros2_rclcpp_typekit
 
-#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_QOS_TYPE_HPP_
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__ROS2_TIME_TYPE_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_conversions.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_conversions.hpp
@@ -15,10 +15,70 @@
 #ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_CONVERSIONS_HPP_
 #define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_CONVERSIONS_HPP_
 
+#include <chrono>
+
+#include "rclcpp/duration.hpp"
+#include "rclcpp/time.hpp"
 #include "rmw/types.h"
+
+#include "wrapped_duration.hpp"
 
 namespace rtt_ros2_rclcpp_typekit
 {
+
+static inline double time_to_double(const rclcpp::Time & t)
+{
+  return t.seconds();
+}
+
+static inline rclcpp::Time double_to_time(const double d)
+{
+  return rclcpp::Time(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(d)).count());
+}
+
+static inline rclcpp::Time double_to_time2(const double d, rcl_clock_type_t clock)
+{
+  return rclcpp::Time(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(d)).count(),
+    clock);
+}
+
+static inline int64_t time_to_int64(const rclcpp::Time & t)
+{
+  return t.nanoseconds();
+}
+
+static inline rclcpp::Time int64_to_time(const int64_t i)
+{
+  return rclcpp::Time(i);
+}
+
+static inline rclcpp::Time int64_to_time2(const int64_t i, rcl_clock_type_t clock)
+{
+  return rclcpp::Time(i, clock);
+}
+
+static inline double duration_to_double(const WrappedDuration & t)
+{
+  return t.seconds();
+}
+
+static inline WrappedDuration double_to_duration(const double d)
+{
+  return WrappedDuration(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(d)).count());
+}
+
+static inline int64_t duration_to_int64(const WrappedDuration & t)
+{
+  return t.nanoseconds();
+}
+
+static inline WrappedDuration int64_to_duration(const int64_t i)
+{
+  return WrappedDuration(i);
+}
 
 static inline double rmw_time_t_to_double(const rmw_time_t & t)
 {
@@ -28,9 +88,24 @@ static inline double rmw_time_t_to_double(const rmw_time_t & t)
 
 static inline rmw_time_t double_to_rmw_time_t(const double d)
 {
+  if (d < 0) {throw std::invalid_argument("rmw_time_t cannot be negative");}
   rmw_time_t t;
   t.sec = static_cast<uint64_t>(d);
   t.nsec = static_cast<uint64_t>((d - static_cast<double>(t.sec)) * 1e9);
+  return t;
+}
+
+static inline uint64_t rmw_time_t_to_uint64(const rmw_time_t & t)
+{
+  return
+    static_cast<uint64_t>(t.sec) * 1000000000ull + static_cast<uint64_t>(t.nsec);
+}
+
+static inline rmw_time_t uint64_to_rmw_time_t(const uint64_t d)
+{
+  rmw_time_t t;
+  t.sec = static_cast<uint64_t>(d / 1000000000L);
+  t.nsec = static_cast<uint64_t>(d % 1000000000L);
   return t;
 }
 

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_conversions.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_conversions.hpp
@@ -26,6 +26,16 @@
 namespace rtt_ros2_rclcpp_typekit
 {
 
+static inline builtin_interfaces::msg::Time time_to_msg(const rclcpp::Time & t)
+{
+  return static_cast<builtin_interfaces::msg::Time>(t);
+}
+
+static inline rclcpp::Time msg_to_time(const builtin_interfaces::msg::Time & msg)
+{
+  return rclcpp::Time(msg);
+}
+
 static inline double time_to_double(const rclcpp::Time & t)
 {
   return t.seconds();
@@ -57,6 +67,16 @@ static inline rclcpp::Time int64_to_time(const int64_t i)
 static inline rclcpp::Time int64_to_time2(const int64_t i, rcl_clock_type_t clock)
 {
   return rclcpp::Time(i, clock);
+}
+
+static inline builtin_interfaces::msg::Duration duration_to_msg(const WrappedDuration & t)
+{
+  return static_cast<builtin_interfaces::msg::Duration>(t);
+}
+
+static inline WrappedDuration msg_to_duration(const builtin_interfaces::msg::Duration & msg)
+{
+  return WrappedDuration(msg);
 }
 
 static inline double duration_to_double(const WrappedDuration & t)

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_conversions.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_conversions.hpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_CONVERSIONS_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_CONVERSIONS_HPP_
+
+#include "rmw/types.h"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+static inline double rmw_time_t_to_double(const rmw_time_t & t)
+{
+  return
+    static_cast<double>(t.sec) + static_cast<double>(t.nsec) * 1e-9;
+}
+
+static inline rmw_time_t double_to_rmw_time_t(const double d)
+{
+  rmw_time_t t;
+  t.sec = static_cast<uint64_t>(d);
+  t.nsec = static_cast<uint64_t>((d - static_cast<double>(t.sec)) * 1e9);
+  return t;
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_CONVERSIONS_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_io.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_io.hpp
@@ -17,14 +17,50 @@
 
 #include <iostream>
 
-#include "time_conversions.hpp"
+#include "rclcpp/duration.hpp"
+#include "rclcpp/time.hpp"
+#include "rmw/types.h"
 
-std::ostream & operator<<(std::ostream & os, const rmw_time_t & t)
+#include "time_conversions.hpp"
+#include "wrapped_duration.hpp"
+
+namespace rtt_ros2_rcpcpp_typekit
+{
+
+static inline std::ostream & operator<<(std::ostream & os, const rclcpp::Time & t)
+{
+  return os << t.seconds();
+}
+
+static inline std::istream & operator>>(std::istream & is, rclcpp::Time & t)
+{
+  double d = 0.0;
+  if (is >> d) {
+    t = rtt_ros2_rclcpp_typekit::double_to_time(d);
+  }
+  return is;
+}
+
+static inline std::ostream & operator<<(std::ostream & os, const rclcpp::Duration & t)
+{
+  return os << t.seconds();
+}
+
+static inline std::istream & operator>>(std::istream & is, rclcpp::Duration & t)
+{
+  double d = 0.0;
+  if (is >> d) {
+    t = rtt_ros2_rclcpp_typekit::double_to_duration(d);
+  }
+  return is;
+}
+
+static inline std::ostream & operator<<(std::ostream & os, const rmw_time_t & t)
 {
   return os << rtt_ros2_rclcpp_typekit::rmw_time_t_to_double(t);
 }
 
-std::istream & operator>>(std::istream & is, rmw_time_t & t)
+static inline std::istream & operator>>(std::istream & is, rmw_time_t & t)
 {
   double d = 0.0;
   if (is >> d) {
@@ -32,5 +68,14 @@ std::istream & operator>>(std::istream & is, rmw_time_t & t)
   }
   return is;
 }
+
+}  // namespace rtt_ros2_rcpcpp_typekit
+
+// import streaming operators in namespace RTT for RTT::types::TypeStreamSelector
+namespace RTT
+{
+using rtt_ros2_rcpcpp_typekit::operator<<;
+using rtt_ros2_rcpcpp_typekit::operator>>;
+}  // namespace RTT
 
 #endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_IO_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_io.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_io.hpp
@@ -1,0 +1,36 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_IO_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_IO_HPP_
+
+#include <iostream>
+
+#include "time_conversions.hpp"
+
+std::ostream & operator<<(std::ostream & os, const rmw_time_t & t)
+{
+  return os << rtt_ros2_rclcpp_typekit::rmw_time_t_to_double(t);
+}
+
+std::istream & operator>>(std::istream & is, rmw_time_t & t)
+{
+  double d = 0.0;
+  if (is >> d) {
+    t = rtt_ros2_rclcpp_typekit::double_to_rmw_time_t(d);
+  }
+  return is;
+}
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_IO_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_operators.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/time_operators.hpp
@@ -1,0 +1,85 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_OPERATORS_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_OPERATORS_HPP_
+
+#include <chrono>
+
+#include "rclcpp/duration.hpp"
+#include "rclcpp/time.hpp"
+
+#include "wrapped_duration.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+struct duration_plus_duration
+{
+  typedef WrappedDuration first_argument_type;
+  typedef WrappedDuration second_argument_type;
+  typedef WrappedDuration result_type;
+  WrappedDuration operator()(const WrappedDuration & da, const WrappedDuration & db) const
+  {
+    return da + db;
+  }
+};
+
+struct duration_minus_duration
+{
+  typedef WrappedDuration first_argument_type;
+  typedef WrappedDuration second_argument_type;
+  typedef WrappedDuration result_type;
+  WrappedDuration operator()(const WrappedDuration & da, const WrappedDuration & db) const
+  {
+    return da - db;
+  }
+};
+
+struct time_plus_duration
+{
+  typedef rclcpp::Time first_argument_type;
+  typedef WrappedDuration second_argument_type;
+  typedef rclcpp::Time result_type;
+  rclcpp::Time operator()(const rclcpp::Time & t, const WrappedDuration & d) const
+  {
+    return t + d;
+  }
+};
+
+struct time_minus_duration
+{
+  typedef rclcpp::Time first_argument_type;
+  typedef WrappedDuration second_argument_type;
+  typedef rclcpp::Time result_type;
+  rclcpp::Time operator()(const rclcpp::Time & t, const WrappedDuration & d) const
+  {
+    return t - d;
+  }
+};
+
+struct time_minus_time
+{
+  typedef rclcpp::Time first_argument_type;
+  typedef rclcpp::Time second_argument_type;
+  typedef WrappedDuration result_type;
+  WrappedDuration operator()(const rclcpp::Time & ta, const rclcpp::Time & tb) const
+  {
+    return ta - tb;
+  }
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__TIME_OPERATORS_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/wrapped_duration.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/wrapped_duration.hpp
@@ -1,0 +1,51 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__WRAPPED_DURATION_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__WRAPPED_DURATION_HPP_
+
+#include <utility>
+
+#include "rclcpp/duration.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+// Derived type for RTT, which is default constructible.
+class WrappedDuration : public rclcpp::Duration
+{
+public:
+  WrappedDuration();
+  WrappedDuration(const rclcpp::Duration & duration)  // NOLINT(runtime/explicit)
+  : rclcpp::Duration(duration) {}
+  WrappedDuration(rclcpp::Duration && duration) noexcept  // NOLINT(runtime/explicit)
+  : rclcpp::Duration(std::move(duration)) {}
+  template<typename ... Args>
+  WrappedDuration(Args && ... args)  // NOLINT(runtime/explicit)
+  : rclcpp::Duration(std::forward<Args>(args)...) {}
+  WrappedDuration & operator=(const rclcpp::Duration & duration)
+  {
+    static_cast<rclcpp::Duration &>(*this) = duration;
+    return *this;
+  }
+  WrappedDuration & operator=(rclcpp::Duration && duration) noexcept
+  {
+    static_cast<rclcpp::Duration &>(*this) = std::move(duration);
+    return *this;
+  }
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__WRAPPED_DURATION_HPP_

--- a/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/wrapped_qos.hpp
+++ b/rtt_ros2_rclcpp_typekit/include/orocos/rtt_ros2_rclcpp_typekit/wrapped_qos.hpp
@@ -1,0 +1,51 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__WRAPPED_QOS_HPP_
+#define OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__WRAPPED_QOS_HPP_
+
+#include <utility>
+
+#include "rclcpp/qos.hpp"
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+// Derived type for RTT, which is default constructible.
+class WrappedQoS : public rclcpp::QoS
+{
+public:
+  WrappedQoS();
+  WrappedQoS(const rclcpp::QoS & qos)  // NOLINT(runtime/explicit)
+  : rclcpp::QoS(qos) {}
+  WrappedQoS(rclcpp::QoS && qos) noexcept  // NOLINT(runtime/explicit)
+  : rclcpp::QoS(std::move(qos)) {}
+  template<typename ... Args>
+  WrappedQoS(Args && ... args)  // NOLINT(runtime/explicit)
+  : rclcpp::QoS(std::forward<Args>(args)...) {}
+  WrappedQoS & operator=(const rclcpp::QoS & qos)
+  {
+    static_cast<rclcpp::QoS &>(*this) = qos;
+    return *this;
+  }
+  WrappedQoS & operator=(rclcpp::QoS && qos) noexcept
+  {
+    static_cast<rclcpp::QoS &>(*this) = std::move(qos);
+    return *this;
+  }
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+#endif  // OROCOS__RTT_ROS2_RCLCPP_TYPEKIT__WRAPPED_QOS_HPP_

--- a/rtt_ros2_rclcpp_typekit/package.xml
+++ b/rtt_ros2_rclcpp_typekit/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rtt_ros2_rclcpp_typekit</name>
+  <version>0.0.0</version>
+  <description>
+    Orocos RTT typekit plugin for rclcpp types
+  </description>
+  <maintainer email="orocos-dev@orocos.org">Orocos Developers</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rtt_ros2</depend>
+  <exec_depend>rtt_ros2_primitives_typekit</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rtt_ros2_rclcpp_typekit/src/ros2_duration_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_duration_type.cpp
@@ -48,9 +48,19 @@ bool DurationTypeInfo::installTypeInfoObject(TypeInfo * ti)
   // ti->setStreamFactory(mthis);
 
   // Conversions
-  // Define conversions for int64_t first, because Orocos implicit converts from int64 to double!
   const auto types = TypeInfoRepository::Instance();
   {
+    const auto built_interfaces_msg_duration_ti =
+      types->getTypeInfo<builtin_interfaces::msg::Duration>();
+    assert(built_interfaces_msg_duration_ti != nullptr);
+    if (built_interfaces_msg_duration_ti != nullptr) {
+      built_interfaces_msg_duration_ti->addConstructor(newConstructor(&duration_to_msg, true));
+    }
+    ti->addConstructor(newConstructor(&msg_to_duration, true));
+  }
+  {
+    // Note: Define conversions for int64_t before double, because Orocos implicit converts from
+    // int64_t to double, but not from double to int64_t.
     const auto int64_ti = types->getTypeInfo<int64_t>();
     assert(int64_ti != nullptr);
     if (int64_ti != nullptr) {

--- a/rtt_ros2_rclcpp_typekit/src/ros2_duration_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_duration_type.cpp
@@ -1,0 +1,74 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_duration_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/types/TemplateConstructor.hpp"
+
+#include "rtt_ros2_rclcpp_typekit/time_conversions.hpp"
+#include "rtt_ros2_rclcpp_typekit/time_io.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+WrappedDuration::WrappedDuration()
+: rclcpp::Duration(0) {}
+
+DurationTypeInfo::DurationTypeInfo()
+: PrimitiveTypeInfo<WrappedDuration, true>("/rclcpp/Duration")
+{}
+
+bool DurationTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<DurationTypeInfo> mthis =
+    boost::dynamic_pointer_cast<DurationTypeInfo>(
+    this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<WrappedDuration, true>::installTypeInfoObject(ti);
+  // ti->setStreamFactory(mthis);
+
+  // Conversions
+  // Define conversions for int64_t first, because Orocos implicit converts from int64 to double!
+  const auto types = TypeInfoRepository::Instance();
+  {
+    const auto int64_ti = types->getTypeInfo<int64_t>();
+    assert(int64_ti != nullptr);
+    if (int64_ti != nullptr) {
+      int64_ti->addConstructor(newConstructor(&duration_to_int64));
+    }
+    ti->addConstructor(newConstructor(&int64_to_duration, true));
+  }
+  {
+    const auto double_ti = types->getTypeInfo<double>();
+    assert(double_ti != nullptr);
+    if (double_ti != nullptr) {
+      double_ti->addConstructor(newConstructor(&duration_to_double));
+    }
+    ti->addConstructor(newConstructor(&double_to_duration, true));
+  }
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/ros2_node_options_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_node_options_type.cpp
@@ -1,0 +1,247 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_node_options_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+#include "rtt_ros2/getter_setter_datasource.hpp"
+
+#include "rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+NodeOptionsTypeInfo::NodeOptionsTypeInfo()
+: PrimitiveTypeInfo<rclcpp::NodeOptions>("/rclcpp/NodeOptions")
+{}
+
+bool NodeOptionsTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<NodeOptionsTypeInfo> mthis =
+    boost::dynamic_pointer_cast<NodeOptionsTypeInfo>(this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<rclcpp::NodeOptions>::installTypeInfoObject(ti);
+  // Install the factories specific for this type
+  ti->setMemberFactory(mthis);
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+/**
+ * Returns the list of struct member names of this type.
+ * In case this type is not a struct, returns an empty list.
+ */
+std::vector<std::string> NodeOptionsTypeInfo::getMemberNames() const
+{
+  return {
+    "context",
+    "arguments",
+    "parameter_overrides",
+    "use_global_arguments",
+    "use_intra_process_comms",
+    "start_parameter_services",
+    "start_parameter_event_publisher",
+    "parameter_event_qos",
+    "parameter_event_publisher_options",
+    "allow_undeclared_parameters",
+    "automatically_declare_parameters_from_overrides",
+    "allocator"
+  };
+}
+
+base::DataSourceBase::shared_ptr NodeOptionsTypeInfo::getMember(
+  base::DataSourceBase::shared_ptr item,
+  const std::string & part_name) const
+{
+  typename internal::AssignableDataSource<rclcpp::NodeOptions>::shared_ptr adata =
+    boost::dynamic_pointer_cast<internal::AssignableDataSource<rclcpp::NodeOptions>>(item);
+  // Use a copy in case our parent is not assignable:
+  if (!adata) {
+    // is it non-assignable ?
+    typename internal::DataSource<rclcpp::NodeOptions>::shared_ptr data =
+      boost::dynamic_pointer_cast<internal::DataSource<rclcpp::NodeOptions>>(item);
+    if (data) {
+      // create a copy
+      adata = new internal::ValueDataSource<rclcpp::NodeOptions>(data->get() );
+    }
+  }
+  if (!adata) {
+    log(Error) <<
+      "Wrong call to type info function " + this->getTypeName() <<
+      "'s getMember() can not process " << item->getTypeName() << endlog();
+    return base::DataSourceBase::shared_ptr();
+  }
+
+  if (part_name == "context") {
+    using FieldT = rclcpp::Context::SharedPtr;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::context);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::context);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "arguments") {
+    using FieldT = std::vector<std::string>;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<const FieldT & (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::arguments);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(const FieldT &)>(
+      &rclcpp::NodeOptions::arguments);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "parameter_overrides") {
+    using FieldT = std::vector<rclcpp::Parameter>;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<const FieldT & (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::parameter_overrides);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(const FieldT &)>(
+      &rclcpp::NodeOptions::parameter_overrides);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "use_global_arguments") {
+    using FieldT = bool;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::use_global_arguments);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::use_global_arguments);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "use_intra_process_comms") {
+    using FieldT = bool;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::use_intra_process_comms);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::use_intra_process_comms);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "start_parameter_services") {
+    using FieldT = bool;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::start_parameter_services);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::start_parameter_services);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "start_parameter_event_publisher") {
+    using FieldT = bool;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::start_parameter_event_publisher);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::start_parameter_event_publisher);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "parameter_event_qos") {
+    using FieldT = QoS;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      [](const rclcpp::NodeOptions & node_options) -> QoS {
+        return QoS(node_options.parameter_event_qos());
+      };
+    const auto setter =
+      [](rclcpp::NodeOptions & node_options, const QoS & qos) -> rclcpp::NodeOptions & {
+        return node_options.parameter_event_qos(qos);
+      };
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "parameter_event_publisher_options") {
+    using FieldT = rclcpp::PublisherOptionsBase;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<const FieldT & (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::parameter_event_publisher_options);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(const FieldT &)>(
+      &rclcpp::NodeOptions::parameter_event_publisher_options);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "allow_undeclared_parameters") {
+    using FieldT = bool;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::allow_undeclared_parameters);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::allow_undeclared_parameters);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "automatically_declare_parameters_from_overrides") {
+    using FieldT = bool;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<FieldT (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::automatically_declare_parameters_from_overrides);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::automatically_declare_parameters_from_overrides);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  if (part_name == "allocator") {
+    using FieldT = rcl_allocator_t;
+    using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
+    const auto getter =
+      static_cast<const FieldT & (rclcpp::NodeOptions::*)() const>(
+      &rclcpp::NodeOptions::allocator);
+    const auto setter =
+      static_cast<rclcpp::NodeOptions & (rclcpp::NodeOptions::*)(FieldT)>(
+      &rclcpp::NodeOptions::allocator);
+    return new DataSourceT(adata, getter, setter);
+  }
+
+  return base::DataSourceBase::shared_ptr();
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/ros2_node_options_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_node_options_type.cpp
@@ -23,7 +23,7 @@
 
 #include "rtt_ros2/getter_setter_datasource.hpp"
 
-#include "rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/wrapped_qos.hpp"
 
 using namespace RTT;  // NOLINT(build/namespaces)
 using namespace RTT::types;  // NOLINT(build/namespaces)
@@ -180,14 +180,14 @@ base::DataSourceBase::shared_ptr NodeOptionsTypeInfo::getMember(
   }
 
   if (part_name == "parameter_event_qos") {
-    using FieldT = QoS;
+    using FieldT = WrappedQoS;
     using DataSourceT = rtt_ros2::GetterSetterDataSource<rclcpp::NodeOptions, FieldT>;
     const auto getter =
-      [](const rclcpp::NodeOptions & node_options) -> QoS {
-        return QoS(node_options.parameter_event_qos());
+      [](const rclcpp::NodeOptions & node_options) -> WrappedQoS {
+        return WrappedQoS(node_options.parameter_event_qos());
       };
     const auto setter =
-      [](rclcpp::NodeOptions & node_options, const QoS & qos) -> rclcpp::NodeOptions & {
+      [](rclcpp::NodeOptions & node_options, const WrappedQoS & qos) -> rclcpp::NodeOptions & {
         return node_options.parameter_event_qos(qos);
       };
     return new DataSourceT(adata, getter, setter);

--- a/rtt_ros2_rclcpp_typekit/src/ros2_parameter_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_parameter_type.cpp
@@ -1,0 +1,130 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_parameter_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/internal/FusedFunctorDataSource.hpp"
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+#include "rtt/types/TemplateConstructor.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+namespace
+{
+inline std::string get_type_name(const rclcpp::Parameter & p)
+{
+  return p.get_type_name();
+}
+
+inline const std::string & get_name(const rclcpp::Parameter & p)
+{
+  return p.get_name();
+}
+
+inline const rclcpp::ParameterValue & get_parameter_value(const rclcpp::Parameter & p)
+{
+  return p.get_parameter_value();
+}
+
+inline rclcpp::Parameter construct1(const std::string & name)
+{
+  return rclcpp::Parameter(name);
+}
+
+inline rclcpp::Parameter construct2(const std::string & name, const rclcpp::ParameterValue & value)
+{
+  return rclcpp::Parameter(name, value);
+}
+
+}  // namespace
+
+ParameterTypeInfo::ParameterTypeInfo()
+: PrimitiveTypeInfo<rclcpp::Parameter>("/rclcpp/Parameter")
+{}
+
+bool ParameterTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<ParameterTypeInfo> mthis = boost::dynamic_pointer_cast<ParameterTypeInfo>(
+    this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<rclcpp::Parameter>::installTypeInfoObject(ti);
+  // Install the factories specific for this type
+  ti->setMemberFactory(mthis);
+
+  // Constructors
+  ti->addConstructor(newConstructor(&construct1));
+  ti->addConstructor(newConstructor(&construct2));
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+// copied from StructTypeInfo<T>
+std::vector<std::string> ParameterTypeInfo::getMemberNames() const
+{
+  return {
+    "type_name",
+    "name",
+    "value",
+  };
+}
+
+// copied from StructTypeInfo<T>
+base::DataSourceBase::shared_ptr ParameterTypeInfo::getMember(
+  base::DataSourceBase::shared_ptr item, const std::string & name) const
+{
+  typename internal::AssignableDataSource<rclcpp::Parameter>::shared_ptr adata =
+    boost::dynamic_pointer_cast<internal::AssignableDataSource<rclcpp::Parameter>>(item);
+  // Use a copy in case our parent is not assignable:
+  if (!adata) {
+    // is it non-assignable ?
+    typename internal::DataSource<rclcpp::Parameter>::shared_ptr data =
+      boost::dynamic_pointer_cast<internal::DataSource<rclcpp::Parameter>>(item);
+    if (data) {
+      // create a copy
+      adata = new internal::ValueDataSource<rclcpp::Parameter>(data->get() );
+    }
+  }
+  if (!adata) {
+    log(Error) <<
+      "Wrong call to type info function " + this->getTypeName() <<
+      "'s getMember() can not process " << item->getTypeName() << endlog();
+    return base::DataSourceBase::shared_ptr();
+  }
+
+  if (name == "type_name") {
+    return internal::newFunctorDataSource(&get_type_name, {adata});
+  }
+  if (name == "name") {
+    return internal::newFunctorDataSource(&get_name, {adata});
+  }
+  if (name == "value") {
+    return internal::newFunctorDataSource(&get_parameter_value, {adata});
+  }
+
+  return base::DataSourceBase::shared_ptr();
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/ros2_parameter_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_parameter_type.cpp
@@ -19,8 +19,6 @@
 #include <vector>
 
 #include "rtt/internal/FusedFunctorDataSource.hpp"
-#include "rtt/types/MemberFactory.hpp"
-#include "rtt/types/PrimitiveTypeInfo.hpp"
 #include "rtt/types/TemplateConstructor.hpp"
 
 using namespace RTT;  // NOLINT(build/namespaces)

--- a/rtt_ros2_rclcpp_typekit/src/ros2_parameter_value_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_parameter_value_type.cpp
@@ -18,9 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "rtt/internal/PartDataSource.hpp"
-#include "rtt/types/MemberFactory.hpp"
-#include "rtt/types/PrimitiveTypeInfo.hpp"
 #include "rtt/types/TemplateConstructor.hpp"
 #include "rtt/types/TypeInfoRepository.hpp"
 

--- a/rtt_ros2_rclcpp_typekit/src/ros2_parameter_value_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_parameter_value_type.cpp
@@ -1,0 +1,190 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_parameter_value_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/internal/PartDataSource.hpp"
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+#include "rtt/types/TemplateConstructor.hpp"
+#include "rtt/types/TypeInfoRepository.hpp"
+
+#include "rtt_ros2_rclcpp_typekit/parameter_value_conversions.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+ParameterValueTypeInfo::ParameterValueTypeInfo()
+: PrimitiveTypeInfo<rclcpp::ParameterValue>("/rclcpp/ParameterValue")
+{}
+
+bool ParameterValueTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<ParameterValueTypeInfo> mthis =
+    boost::dynamic_pointer_cast<ParameterValueTypeInfo>(
+    this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<rclcpp::ParameterValue>::installTypeInfoObject(ti);
+  ti->setStreamFactory(mthis);
+
+  // Conversions
+  const auto types = TypeInfoRepository::Instance();
+  {
+    const auto bool_ti = types->getTypeInfo<bool>();
+    assert(bool_ti != nullptr);
+    if (bool_ti != nullptr) {
+      bool_ti->addConstructor(newConstructor(&parameter_value_to_bool));
+    }
+    ti->addConstructor(newConstructor(&bool_to_parameter_value, true));
+  }
+  {
+    const auto int_ti = types->getTypeInfo<int>();
+    assert(int_ti != nullptr);
+    if (int_ti != nullptr) {
+      int_ti->addConstructor(newConstructor(&parameter_value_to_int));
+    }
+    ti->addConstructor(newConstructor(&int_to_parameter_value, true));
+  }
+  {
+    const auto int64_ti = types->getTypeInfo<int64_t>();
+    assert(int64_ti != nullptr);
+    if (int64_ti != nullptr) {
+      int64_ti->addConstructor(newConstructor(&parameter_value_to_int64));
+    }
+    ti->addConstructor(newConstructor(&int64_to_parameter_value, true));
+  }
+  {
+    const auto float_ti = types->getTypeInfo<float>();
+    assert(float_ti != nullptr);
+    if (float_ti != nullptr) {
+      float_ti->addConstructor(newConstructor(&parameter_value_to_float));
+    }
+    ti->addConstructor(newConstructor(&float_to_parameter_value, true));
+  }
+  {
+    const auto double_ti = types->getTypeInfo<double>();
+    assert(double_ti != nullptr);
+    if (double_ti != nullptr) {
+      double_ti->addConstructor(newConstructor(&parameter_value_to_double));
+    }
+    ti->addConstructor(newConstructor(&double_to_parameter_value, true));
+  }
+  {
+    const auto string_ti = types->getTypeInfo<std::string>();
+    assert(string_ti != nullptr);
+    if (string_ti != nullptr) {
+      string_ti->addConstructor(newConstructor(&parameter_value_to_string));
+    }
+    ti->addConstructor(newConstructor(&string_to_parameter_value, true));
+  }
+  {
+    const auto byte_array_ti = types->getTypeInfo<std::vector<uint8_t>>();
+    assert(byte_array_ti != nullptr);
+    if (byte_array_ti != nullptr) {
+      byte_array_ti->addConstructor(newConstructor(&parameter_value_to_byte_array));
+    }
+    ti->addConstructor(newConstructor(&byte_array_to_parameter_value, true));
+  }
+  {
+    const auto bool_array_ti = types->getTypeInfo<std::vector<bool>>();
+    assert(bool_array_ti != nullptr);
+    if (bool_array_ti != nullptr) {
+      bool_array_ti->addConstructor(newConstructor(&parameter_value_to_bool_array));
+    }
+    ti->addConstructor(newConstructor(&bool_array_to_parameter_value, true));
+  }
+  {
+    const auto bool_array_ti = types->getTypeInfo<std::vector<bool>>();
+    assert(bool_array_ti != nullptr);
+    if (bool_array_ti != nullptr) {
+      bool_array_ti->addConstructor(newConstructor(&parameter_value_to_bool_array));
+    }
+    ti->addConstructor(newConstructor(&bool_array_to_parameter_value, true));
+  }
+  {
+    const auto int64_array_ti = types->getTypeInfo<std::vector<int64_t>>();
+    assert(int64_array_ti != nullptr);
+    if (int64_array_ti != nullptr) {
+      int64_array_ti->addConstructor(newConstructor(&parameter_value_to_int64_array));
+    }
+    ti->addConstructor(newConstructor(&int64_array_to_parameter_value, true));
+  }
+  {
+    const auto int_array_ti = types->getTypeInfo<std::vector<int>>();
+    assert(int_array_ti != nullptr);
+    if (int_array_ti != nullptr) {
+      int_array_ti->addConstructor(newConstructor(&parameter_value_to_int_array));
+    }
+    ti->addConstructor(newConstructor(&int_array_to_parameter_value, true));
+  }
+  {
+    const auto float_array_ti = types->getTypeInfo<std::vector<float>>();
+    assert(float_array_ti != nullptr);
+    if (float_array_ti != nullptr) {
+      float_array_ti->addConstructor(newConstructor(&parameter_value_to_float_array));
+    }
+    ti->addConstructor(newConstructor(&float_array_to_parameter_value, true));
+  }
+  {
+    const auto double_array_ti = types->getTypeInfo<std::vector<double>>();
+    assert(double_array_ti != nullptr);
+    if (double_array_ti != nullptr) {
+      double_array_ti->addConstructor(newConstructor(&parameter_value_to_double_array));
+    }
+    ti->addConstructor(newConstructor(&double_array_to_parameter_value, true));
+  }
+  {
+    const auto string_array_ti = types->getTypeInfo<std::vector<std::string>>();
+    assert(string_array_ti != nullptr);
+    if (string_array_ti != nullptr) {
+      string_array_ti->addConstructor(newConstructor(&parameter_value_to_string_array));
+    }
+    ti->addConstructor(newConstructor(&string_array_to_parameter_value, true));
+  }
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+std::ostream & ParameterValueTypeInfo::write(
+  std::ostream & os,
+  RTT::base::DataSourceBase::shared_ptr in) const
+{
+  typename internal::DataSource<rclcpp::ParameterValue>::shared_ptr d =
+    boost::dynamic_pointer_cast<internal::DataSource<rclcpp::ParameterValue>>(in);
+  if (d) {
+    os << to_string(d->rvalue());
+  }
+  return os;
+}
+
+std::istream & ParameterValueTypeInfo::read(
+  std::istream & is,
+  RTT::base::DataSourceBase::shared_ptr /*out*/) const
+{
+  // not supported
+  is.setstate(std::ios_base::failbit);
+  return is;
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/ros2_publisher_options_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_publisher_options_type.cpp
@@ -1,0 +1,116 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_publisher_options_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/internal/PartDataSource.hpp"
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+#include "rtt_ros2_rclcpp_typekit/wrapped_qos.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+PublisherOptionsBaseTypeInfo::PublisherOptionsBaseTypeInfo()
+: PrimitiveTypeInfo<rclcpp::PublisherOptionsBase>("/rclcpp/PublisherOptionsBase")
+{}
+
+bool PublisherOptionsBaseTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<PublisherOptionsBaseTypeInfo> mthis =
+    boost::dynamic_pointer_cast<PublisherOptionsBaseTypeInfo>(this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<rclcpp::PublisherOptionsBase>::installTypeInfoObject(ti);
+  // Install the factories specific for this type
+  ti->setMemberFactory(mthis);
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+/**
+ * Returns the list of struct member names of this type.
+ * In case this type is not a struct, returns an empty list.
+ */
+std::vector<std::string> PublisherOptionsBaseTypeInfo::getMemberNames() const
+{
+  return {
+    "use_intra_process_comm",
+    "event_callbacks",
+    "callback_group",
+    "rmw_implementation_payload",
+  };
+}
+
+base::DataSourceBase::shared_ptr PublisherOptionsBaseTypeInfo::getMember(
+  base::DataSourceBase::shared_ptr item,
+  const std::string & part_name) const
+{
+  typename internal::AssignableDataSource<rclcpp::PublisherOptionsBase>::shared_ptr adata =
+    boost::dynamic_pointer_cast<internal::AssignableDataSource<rclcpp::PublisherOptionsBase>>(item);
+  // Use a copy in case our parent is not assignable:
+  if (!adata) {
+    // is it non-assignable ?
+    typename internal::DataSource<rclcpp::PublisherOptionsBase>::shared_ptr data =
+      boost::dynamic_pointer_cast<internal::DataSource<rclcpp::PublisherOptionsBase>>(item);
+    if (data) {
+      // create a copy
+      adata = new internal::ValueDataSource<rclcpp::PublisherOptionsBase>(data->get() );
+    }
+  }
+  if (!adata) {
+    log(Error) <<
+      "Wrong call to type info function " + this->getTypeName() <<
+      "'s getMember() can not process " << item->getTypeName() << endlog();
+    return base::DataSourceBase::shared_ptr();
+  }
+
+  if (part_name == "use_intra_process_comm") {
+    using FieldT = decltype(rclcpp::PublisherOptionsBase::use_intra_process_comm);
+    using DataSourceT = internal::PartDataSource<FieldT>;
+    return new DataSourceT(adata->set().use_intra_process_comm, item);
+  }
+
+  if (part_name == "event_callbacks") {
+    using FieldT = decltype(rclcpp::PublisherOptionsBase::event_callbacks);
+    using DataSourceT = internal::PartDataSource<FieldT>;
+    return new DataSourceT(adata->set().event_callbacks, item);
+  }
+
+  if (part_name == "callback_group") {
+    using FieldT = decltype(rclcpp::PublisherOptionsBase::callback_group);
+    using DataSourceT = internal::PartDataSource<FieldT>;
+    return new DataSourceT(adata->set().callback_group, item);
+  }
+
+  if (part_name == "rmw_implementation_payload") {
+    using FieldT = decltype(rclcpp::PublisherOptionsBase::rmw_implementation_payload);
+    using DataSourceT = internal::PartDataSource<FieldT>;
+    return new DataSourceT(adata->set().rmw_implementation_payload, item);
+  }
+
+  return base::DataSourceBase::shared_ptr();
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/ros2_publisher_options_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_publisher_options_type.cpp
@@ -22,6 +22,7 @@
 #include "rtt/types/MemberFactory.hpp"
 #include "rtt/types/PrimitiveTypeInfo.hpp"
 
+#include "rtt_ros2_rclcpp_typekit/rclcpp_version.h"
 #include "rtt_ros2_rclcpp_typekit/wrapped_qos.hpp"
 
 using namespace RTT;  // NOLINT(build/namespaces)
@@ -59,7 +60,9 @@ std::vector<std::string> PublisherOptionsBaseTypeInfo::getMemberNames() const
     "use_intra_process_comm",
     "event_callbacks",
     "callback_group",
+#if rclcpp_VERSION_GTE(0, 8, 1)
     "rmw_implementation_payload",
+#endif
   };
 }
 
@@ -104,11 +107,13 @@ base::DataSourceBase::shared_ptr PublisherOptionsBaseTypeInfo::getMember(
     return new DataSourceT(adata->set().callback_group, item);
   }
 
+#if rclcpp_VERSION_GTE(0, 8, 1)
   if (part_name == "rmw_implementation_payload") {
     using FieldT = decltype(rclcpp::PublisherOptionsBase::rmw_implementation_payload);
     using DataSourceT = internal::PartDataSource<FieldT>;
     return new DataSourceT(adata->set().rmw_implementation_payload, item);
   }
+#endif
 
   return base::DataSourceBase::shared_ptr();
 }

--- a/rtt_ros2_rclcpp_typekit/src/ros2_qos_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_qos_type.cpp
@@ -1,0 +1,133 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/internal/PartDataSource.hpp"
+#include "rtt/types/MemberFactory.hpp"
+#include "rtt/types/PrimitiveTypeInfo.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+QoS::QoS()
+: QoS(rclcpp::KeepLast(0)) {}
+
+QoSTypeInfo::QoSTypeInfo()
+: PrimitiveTypeInfo<QoS>("/rclcpp/QoS")
+{}
+
+bool QoSTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<QoSTypeInfo> mthis = boost::dynamic_pointer_cast<QoSTypeInfo>(
+    this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<QoS>::installTypeInfoObject(ti);
+  // Install the factories specific for this type
+  ti->setMemberFactory(mthis);
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+// copied from StructTypeInfo<T>
+std::vector<std::string> QoSTypeInfo::getMemberNames() const
+{
+  return {
+    "history",
+    "depth",
+    "reliability",
+    "durability",
+    "deadline",
+    "lifespan",
+    "liveliness",
+    "liveliness_lease_duration",
+    "avoid_ros_namespace_conventions",
+  };
+}
+
+// copied from StructTypeInfo<T>
+base::DataSourceBase::shared_ptr QoSTypeInfo::getMember(
+  base::DataSourceBase::shared_ptr item, const std::string & name) const
+{
+  typename internal::AssignableDataSource<QoS>::shared_ptr adata =
+    boost::dynamic_pointer_cast<internal::AssignableDataSource<QoS>>(item);
+  // Use a copy in case our parent is not assignable:
+  if (!adata) {
+    // is it non-assignable ?
+    typename internal::DataSource<QoS>::shared_ptr data =
+      boost::dynamic_pointer_cast<internal::DataSource<QoS>>(item);
+    if (data) {
+      // create a copy
+      adata = new internal::ValueDataSource<QoS>(data->get() );
+    }
+  }
+  if (!adata) {
+    log(Error) <<
+      "Wrong call to type info function " + this->getTypeName() <<
+      "'s getMember() can not process " << item->getTypeName() << endlog();
+    return base::DataSourceBase::shared_ptr();
+  }
+
+  if (name == "history") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::history)>(
+      adata->set().get_rmw_qos_profile().history, item);
+  }
+  if (name == "depth") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::depth)>(
+      adata->set().get_rmw_qos_profile().depth, item);
+  }
+  if (name == "reliability") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::reliability)>(
+      adata->set().get_rmw_qos_profile().reliability, item);
+  }
+  if (name == "durability") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::durability)>(
+      adata->set().get_rmw_qos_profile().durability, item);
+  }
+  if (name == "deadline") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::deadline)>(
+      adata->set().get_rmw_qos_profile().deadline, item);
+  }
+  if (name == "lifespan") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::lifespan)>(
+      adata->set().get_rmw_qos_profile().lifespan, item);
+  }
+  if (name == "liveliness") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::liveliness)>(
+      adata->set().get_rmw_qos_profile().liveliness, item);
+  }
+  if (name == "liveliness_lease_duration") {
+    return new internal::PartDataSource<decltype(rmw_qos_profile_t::liveliness_lease_duration)>(
+      adata->set().get_rmw_qos_profile().liveliness_lease_duration, item);
+  }
+  if (name == "avoid_ros_namespace_conventions") {
+    return new internal::PartDataSource<
+      decltype(rmw_qos_profile_t::avoid_ros_namespace_conventions)>(
+      adata->set().get_rmw_qos_profile().avoid_ros_namespace_conventions, item);
+  }
+
+  return base::DataSourceBase::shared_ptr();
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/ros2_qos_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_qos_type.cpp
@@ -28,11 +28,11 @@ using namespace RTT::types;  // NOLINT(build/namespaces)
 namespace rtt_ros2_rclcpp_typekit
 {
 
-QoS::QoS()
-: QoS(rclcpp::KeepLast(0)) {}
+WrappedQoS::WrappedQoS()
+: rclcpp::QoS(rclcpp::KeepLast(0)) {}
 
 QoSTypeInfo::QoSTypeInfo()
-: PrimitiveTypeInfo<QoS>("/rclcpp/QoS")
+: PrimitiveTypeInfo<WrappedQoS>("/rclcpp/QoS")
 {}
 
 bool QoSTypeInfo::installTypeInfoObject(TypeInfo * ti)
@@ -42,7 +42,7 @@ bool QoSTypeInfo::installTypeInfoObject(TypeInfo * ti)
     this->getSharedPtr());
   assert(mthis);
   // Allow base to install first
-  PrimitiveTypeInfo<QoS>::installTypeInfoObject(ti);
+  PrimitiveTypeInfo<WrappedQoS>::installTypeInfoObject(ti);
   // Install the factories specific for this type
   ti->setMemberFactory(mthis);
 
@@ -70,16 +70,16 @@ std::vector<std::string> QoSTypeInfo::getMemberNames() const
 base::DataSourceBase::shared_ptr QoSTypeInfo::getMember(
   base::DataSourceBase::shared_ptr item, const std::string & name) const
 {
-  typename internal::AssignableDataSource<QoS>::shared_ptr adata =
-    boost::dynamic_pointer_cast<internal::AssignableDataSource<QoS>>(item);
+  typename internal::AssignableDataSource<WrappedQoS>::shared_ptr adata =
+    boost::dynamic_pointer_cast<internal::AssignableDataSource<WrappedQoS>>(item);
   // Use a copy in case our parent is not assignable:
   if (!adata) {
     // is it non-assignable ?
-    typename internal::DataSource<QoS>::shared_ptr data =
-      boost::dynamic_pointer_cast<internal::DataSource<QoS>>(item);
+    typename internal::DataSource<WrappedQoS>::shared_ptr data =
+      boost::dynamic_pointer_cast<internal::DataSource<WrappedQoS>>(item);
     if (data) {
       // create a copy
-      adata = new internal::ValueDataSource<QoS>(data->get() );
+      adata = new internal::ValueDataSource<WrappedQoS>(data->get() );
     }
   }
   if (!adata) {

--- a/rtt_ros2_rclcpp_typekit/src/ros2_time_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_time_type.cpp
@@ -45,9 +45,19 @@ bool TimeTypeInfo::installTypeInfoObject(TypeInfo * ti)
   // ti->setStreamFactory(mthis);
 
   // Conversions
-  // Define conversions for int64_t first, because Orocos implicit converts from int64 to double!
   const auto types = TypeInfoRepository::Instance();
   {
+    const auto built_interfaces_msg_time_ti =
+      types->getTypeInfo<builtin_interfaces::msg::Time>();
+    assert(built_interfaces_msg_time_ti != nullptr);
+    if (built_interfaces_msg_time_ti != nullptr) {
+      built_interfaces_msg_time_ti->addConstructor(newConstructor(&time_to_msg, true));
+    }
+    ti->addConstructor(newConstructor(&msg_to_time, true));
+  }
+  {
+    // Note: Define conversions for int64_t before double, because Orocos implicit converts from
+    // int64_t to double, but not from double to int64_t.
     const auto int64_ti = types->getTypeInfo<int64_t>();
     assert(int64_ti != nullptr);
     if (int64_ti != nullptr) {

--- a/rtt_ros2_rclcpp_typekit/src/ros2_time_type.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/ros2_time_type.cpp
@@ -1,0 +1,73 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rtt_ros2_rclcpp_typekit/ros2_time_type.hpp"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rtt/types/TemplateConstructor.hpp"
+
+#include "rtt_ros2_rclcpp_typekit/time_conversions.hpp"
+#include "rtt_ros2_rclcpp_typekit/time_io.hpp"
+
+using namespace RTT;  // NOLINT(build/namespaces)
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+TimeTypeInfo::TimeTypeInfo()
+: PrimitiveTypeInfo<rclcpp::Time, true>("/rclcpp/Time")
+{}
+
+bool TimeTypeInfo::installTypeInfoObject(TypeInfo * ti)
+{
+  // aquire a shared reference to the this object
+  boost::shared_ptr<TimeTypeInfo> mthis =
+    boost::dynamic_pointer_cast<TimeTypeInfo>(
+    this->getSharedPtr());
+  assert(mthis);
+  // Allow base to install first
+  PrimitiveTypeInfo<rclcpp::Time, true>::installTypeInfoObject(ti);
+  // ti->setStreamFactory(mthis);
+
+  // Conversions
+  // Define conversions for int64_t first, because Orocos implicit converts from int64 to double!
+  const auto types = TypeInfoRepository::Instance();
+  {
+    const auto int64_ti = types->getTypeInfo<int64_t>();
+    assert(int64_ti != nullptr);
+    if (int64_ti != nullptr) {
+      int64_ti->addConstructor(newConstructor(&time_to_int64));
+    }
+    ti->addConstructor(newConstructor(&int64_to_time, true));
+    ti->addConstructor(newConstructor(&int64_to_time2));
+  }
+  {
+    const auto double_ti = types->getTypeInfo<double>();
+    assert(double_ti != nullptr);
+    if (double_ti != nullptr) {
+      double_ti->addConstructor(newConstructor(&time_to_double));
+    }
+    ti->addConstructor(newConstructor(&double_to_time, true));
+    ti->addConstructor(newConstructor(&double_to_time2));
+  }
+
+  // Don't delete us, we're memory-managed.
+  return false;
+}
+
+}  // namespace rtt_ros2_rclcpp_typekit

--- a/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
@@ -1,0 +1,144 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "rtt/types/EnumTypeInfo.hpp"
+#include "rtt/types/GlobalsRepository.hpp"
+#include "rtt/types/SequenceTypeInfo.hpp"
+#include "rtt/types/TypekitPlugin.hpp"
+
+#include "rtt_ros2_rclcpp_typekit/ros2_node_options_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/ros2_parameter_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/ros2_parameter_value_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/time_conversions.hpp"
+#include "rtt_ros2_rclcpp_typekit/time_io.hpp"
+
+using namespace RTT::types;  // NOLINT(build/namespaces)
+
+namespace rtt_ros2_rclcpp_typekit
+{
+
+class TypekitPlugin : public RTT::types::TypekitPlugin
+{
+public:
+  bool loadTypes() override
+  {
+    const auto types = Types();
+
+    types->addType(new NodeOptionsTypeInfo());
+    types->addType(new ParameterTypeInfo());
+    types->addType(new SequenceTypeInfo<std::vector<rclcpp::Parameter>>("/rclcpp/Parameter[]"));
+    types->addType(new ParameterValueTypeInfo());
+    types->addType(new QoSTypeInfo());
+
+    types->addType(new PrimitiveTypeInfo<rmw_time_t, true>("rmw_time_t"));
+    types->addType(new EnumTypeInfo<rmw_qos_history_policy_t>("rmw_qos_history_policy_t"));
+    types->addType(new EnumTypeInfo<rmw_qos_reliability_policy_t>("rmw_qos_reliability_policy_t"));
+    types->addType(new EnumTypeInfo<rmw_qos_durability_policy_t>("rmw_qos_durability_policy_t"));
+    types->addType(new EnumTypeInfo<rmw_qos_liveliness_policy_t>("rmw_qos_liveliness_policy_t"));
+
+    return true;
+  }
+
+  bool loadOperators() override {return true;}
+  bool loadConstructors() override
+  {
+    const auto types = Types();
+
+    // rmw_time_t <-> double
+    types->type("rmw_time_t")->addConstructor(newConstructor(&double_to_rmw_time_t, true));
+    types->type("double")->addConstructor(newConstructor(&rmw_time_t_to_double, true));
+
+    return true;
+  }
+
+  bool loadGlobals() override
+  {
+    const auto globals = GlobalsRepository::Instance();
+
+    // rmw_qos_reliability_policy_t
+    globals->addConstant<rmw_qos_reliability_policy_t>(
+      "RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT",
+      RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT);
+    globals->addConstant<rmw_qos_reliability_policy_t>(
+      "RMW_QOS_POLICY_RELIABILITY_RELIABLE",
+      RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    globals->addConstant<rmw_qos_reliability_policy_t>(
+      "RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT",
+      RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
+    globals->addConstant<rmw_qos_reliability_policy_t>(
+      "RMW_QOS_POLICY_RELIABILITY_UNKNOWN",
+      RMW_QOS_POLICY_RELIABILITY_UNKNOWN);
+
+    // rmw_qos_history_policy_t
+    globals->addConstant<rmw_qos_history_policy_t>(
+      "RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT",
+      RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT);
+    globals->addConstant<rmw_qos_history_policy_t>(
+      "RMW_QOS_POLICY_HISTORY_KEEP_LAST",
+      RMW_QOS_POLICY_HISTORY_KEEP_LAST);
+    globals->addConstant<rmw_qos_history_policy_t>(
+      "RMW_QOS_POLICY_HISTORY_KEEP_ALL",
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL);
+    globals->addConstant<rmw_qos_history_policy_t>(
+      "RMW_QOS_POLICY_HISTORY_UNKNOWN",
+      RMW_QOS_POLICY_HISTORY_UNKNOWN);
+
+    // rmw_qos_durability_policy_t
+    globals->addConstant<rmw_qos_durability_policy_t>(
+      "RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT",
+      RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT);
+    globals->addConstant<rmw_qos_durability_policy_t>(
+      "RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL",
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    globals->addConstant<rmw_qos_durability_policy_t>(
+      "RMW_QOS_POLICY_DURABILITY_VOLATILE",
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    globals->addConstant<rmw_qos_durability_policy_t>(
+      "RMW_QOS_POLICY_DURABILITY_UNKNOWN",
+      RMW_QOS_POLICY_DURABILITY_UNKNOWN);
+
+    // rmw_qos_liveliness_policy_t
+    globals->addConstant<rmw_qos_liveliness_policy_t>(
+      "RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT",
+      RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT);
+    globals->addConstant<rmw_qos_liveliness_policy_t>(
+      "RMW_QOS_POLICY_LIVELINESS_AUTOMATIC",
+      RMW_QOS_POLICY_LIVELINESS_AUTOMATIC);
+    globals->addConstant<rmw_qos_liveliness_policy_t>(
+      "RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE",
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE);
+    globals->addConstant<rmw_qos_liveliness_policy_t>(
+      "RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC",
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC);
+    globals->addConstant<rmw_qos_liveliness_policy_t>(
+      "RMW_QOS_POLICY_LIVELINESS_UNKNOWN",
+      RMW_QOS_POLICY_LIVELINESS_UNKNOWN);
+
+    return true;
+  }
+
+  std::string getName() override
+  {
+    static const std::string name = "ros2-rclcpp";
+    return name;
+  }
+};
+
+}  // namespace rtt_ros2_rclcpp_typekit
+
+ORO_TYPEKIT_PLUGIN(rtt_ros2_rclcpp_typekit::TypekitPlugin)

--- a/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
@@ -60,10 +60,17 @@ public:
     types->addType(
       new PrimitiveTypeInfo<rclcpp::PublisherEventCallbacks>(
         "/rclcpp/PublisherEventCallbacks"));
+#if rclcpp_VERSION_GTE(0, 9, 0)
+    types->addType(
+      new PrimitiveTypeInfo<
+        std::shared_ptr<rclcpp::CallbackGroup>>(
+        "/rclcpp/CallbackGroup"));
+#else
     types->addType(
       new PrimitiveTypeInfo<
         std::shared_ptr<rclcpp::callback_group::CallbackGroup>>(
         "/rclcpp/CallbackGroup"));
+#endif
 #if rclcpp_VERSION_GTE(0, 8, 1)
     types->addType(
       new PrimitiveTypeInfo<

--- a/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
@@ -12,20 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "rtt/types/EnumTypeInfo.hpp"
 #include "rtt/types/GlobalsRepository.hpp"
 #include "rtt/types/SequenceTypeInfo.hpp"
+#include "rtt/types/OperatorTypes.hpp"
 #include "rtt/types/TypekitPlugin.hpp"
 
+#include "rtt_ros2_rclcpp_typekit/ros2_duration_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/ros2_node_options_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/ros2_parameter_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/ros2_parameter_value_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/ros2_publisher_options_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/ros2_qos_type.hpp"
+#include "rtt_ros2_rclcpp_typekit/ros2_time_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/time_conversions.hpp"
 #include "rtt_ros2_rclcpp_typekit/time_io.hpp"
+#include "rtt_ros2_rclcpp_typekit/time_operators.hpp"
+#include "rtt_ros2_rclcpp_typekit/wrapped_duration.hpp"
 
 using namespace RTT::types;  // NOLINT(build/namespaces)
 
@@ -39,13 +46,31 @@ public:
   {
     const auto types = Types();
 
+    types->addType(new DurationTypeInfo());
+    types->addType(new TimeTypeInfo());
     types->addType(new NodeOptionsTypeInfo());
     types->addType(new ParameterTypeInfo());
     types->addType(new SequenceTypeInfo<std::vector<rclcpp::Parameter>>("/rclcpp/Parameter[]"));
     types->addType(new ParameterValueTypeInfo());
+    types->addType(new PublisherOptionsBaseTypeInfo());
     types->addType(new QoSTypeInfo());
 
+    types->addType(new EnumTypeInfo<rclcpp::IntraProcessSetting>("/rclcpp/IntraProcessSetting"));
+    types->addType(
+      new PrimitiveTypeInfo<rclcpp::PublisherEventCallbacks>(
+        "/rclcpp/PublisherEventCallbacks"));
+    types->addType(
+      new PrimitiveTypeInfo<
+        std::shared_ptr<rclcpp::callback_group::CallbackGroup>>(
+        "/rclcpp/CallbackGroup"));
+    types->addType(
+      new PrimitiveTypeInfo<
+        std::shared_ptr<rclcpp::detail::RMWImplementationSpecificPublisherPayload>>(
+        "/rclcpp/RMWImplementationSpecificPublisherPayload"));
+
     types->addType(new PrimitiveTypeInfo<rmw_time_t, true>("rmw_time_t"));
+    types->addType(new PrimitiveTypeInfo<rcl_allocator_t>("rcl_allocator_t"));
+    types->addType(new EnumTypeInfo<rcl_clock_type_t>("rcl_clock_type_t"));
     types->addType(new EnumTypeInfo<rmw_qos_history_policy_t>("rmw_qos_history_policy_t"));
     types->addType(new EnumTypeInfo<rmw_qos_reliability_policy_t>("rmw_qos_reliability_policy_t"));
     types->addType(new EnumTypeInfo<rmw_qos_durability_policy_t>("rmw_qos_durability_policy_t"));
@@ -54,14 +79,35 @@ public:
     return true;
   }
 
-  bool loadOperators() override {return true;}
+  bool loadOperators() override
+  {
+    const auto operators = OperatorRepository::Instance();
+
+    // Duration
+    operators->add(newBinaryOperator("+", duration_plus_duration()));
+    operators->add(newBinaryOperator("-", duration_minus_duration()));
+
+    // Time +/- Duration
+    operators->add(newBinaryOperator("+", time_plus_duration()));
+    operators->add(newBinaryOperator("-", time_minus_duration()));
+
+    // Time - Time
+    operators->add(newBinaryOperator("-", time_minus_time()));
+
+    return true;
+  }
+
   bool loadConstructors() override
   {
     const auto types = Types();
 
     // rmw_time_t <-> double
-    types->type("rmw_time_t")->addConstructor(newConstructor(&double_to_rmw_time_t, true));
-    types->type("double")->addConstructor(newConstructor(&rmw_time_t_to_double, true));
+    types->getTypeInfo<rmw_time_t>()->addConstructor(newConstructor(&double_to_rmw_time_t));
+    types->getTypeInfo<double>()->addConstructor(newConstructor(&rmw_time_t_to_double));
+
+    // rmw_time_t <-> uint64
+    types->getTypeInfo<rmw_time_t>()->addConstructor(newConstructor(&uint64_to_rmw_time_t));
+    types->getTypeInfo<uint64_t>()->addConstructor(newConstructor(&rmw_time_t_to_uint64));
 
     return true;
   }
@@ -69,6 +115,23 @@ public:
   bool loadGlobals() override
   {
     const auto globals = GlobalsRepository::Instance();
+
+    // rclcpp::IntraProcessSetting
+    globals->addConstant<rclcpp::IntraProcessSetting>(
+      "IntraProcessSettingEnable",
+      rclcpp::IntraProcessSetting::Enable);
+    globals->addConstant<rclcpp::IntraProcessSetting>(
+      "IntraProcessSettingDisable",
+      rclcpp::IntraProcessSetting::Disable);
+    globals->addConstant<rclcpp::IntraProcessSetting>(
+      "IntraProcessSettingNodeDefault",
+      rclcpp::IntraProcessSetting::NodeDefault);
+
+    // rcl_clock_type_t
+    globals->addConstant<rcl_clock_type_t>("RCL_CLOCK_UNINITIALIZED", RCL_CLOCK_UNINITIALIZED);
+    globals->addConstant<rcl_clock_type_t>("RCL_ROS_TIME", RCL_ROS_TIME);
+    globals->addConstant<rcl_clock_type_t>("RCL_SYSTEM_TIME", RCL_SYSTEM_TIME);
+    globals->addConstant<rcl_clock_type_t>("RCL_STEADY_TIME", RCL_STEADY_TIME);
 
     // rmw_qos_reliability_policy_t
     globals->addConstant<rmw_qos_reliability_policy_t>(

--- a/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
+++ b/rtt_ros2_rclcpp_typekit/src/rtt_ros2_rclcpp_typekit.cpp
@@ -22,6 +22,7 @@
 #include "rtt/types/OperatorTypes.hpp"
 #include "rtt/types/TypekitPlugin.hpp"
 
+#include "rtt_ros2_rclcpp_typekit/rclcpp_version.h"
 #include "rtt_ros2_rclcpp_typekit/ros2_duration_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/ros2_node_options_type.hpp"
 #include "rtt_ros2_rclcpp_typekit/ros2_parameter_type.hpp"
@@ -63,10 +64,12 @@ public:
       new PrimitiveTypeInfo<
         std::shared_ptr<rclcpp::callback_group::CallbackGroup>>(
         "/rclcpp/CallbackGroup"));
+#if rclcpp_VERSION_GTE(0, 8, 1)
     types->addType(
       new PrimitiveTypeInfo<
         std::shared_ptr<rclcpp::detail::RMWImplementationSpecificPublisherPayload>>(
         "/rclcpp/RMWImplementationSpecificPublisherPayload"));
+#endif
 
     types->addType(new PrimitiveTypeInfo<rmw_time_t, true>("rmw_time_t"));
     types->addType(new PrimitiveTypeInfo<rcl_allocator_t>("rcl_allocator_t"));

--- a/tests/rtt_ros2_idl_tests/test/test_typekit.cpp
+++ b/tests/rtt_ros2_idl_tests/test/test_typekit.cpp
@@ -29,12 +29,12 @@
 /* True if the version of test_msgs is at least major.minor.patch */
 // (from https://github.com/ros2/rmw_cyclonedds/pull/51)
 #define test_msgs_VERSION_GTE(major, minor, patch) ( \
-    major<test_msgs_VERSION_MAJOR ? true \
-    : major> test_msgs_VERSION_MAJOR ? false \
-    : minor<test_msgs_VERSION_MINOR ? true \
-    : minor> test_msgs_VERSION_MINOR ? false \
-    : patch<test_msgs_VERSION_PATCH ? true \
-    : patch> test_msgs_VERSION_PATCH ? false \
+    (major < test_msgs_VERSION_MAJOR) ? true \
+    : (major > test_msgs_VERSION_MAJOR) ? false \
+    : (minor < test_msgs_VERSION_MINOR) ? true \
+    : (minor > test_msgs_VERSION_MINOR) ? false \
+    : (patch < test_msgs_VERSION_PATCH) ? true \
+    : (patch > test_msgs_VERSION_PATCH) ? false \
     : true)
 
 /*


### PR DESCRIPTION
Those types are required to configure ROS 2 nodes from Orocos scripting and the TaskBrowser.