### PR TITLE
rtt_ros2_node: Add free functions getNodeService(tc) and getNode(tc)

### DIFF
--- a/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
+++ b/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
@@ -30,6 +30,8 @@ namespace rtt_ros2_node
 struct Node : public RTT::Service
 {
 public:
+  using shared_ptr = boost::shared_ptr<Node>;
+
   explicit Node(RTT::TaskContext * owner = nullptr);
   Node(
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
@@ -56,6 +58,23 @@ protected:
   rclcpp::executor::Executor::SharedPtr executor_;
   std::thread thread_;
 };
+
+/// Retrieve a pointer to the rtt_ros2_node::Node service to be used for the given TaskContext.
+/**
+ * @param tc The TaskContext instance for which to retrieve a Node pointer. If nullptr, consider
+ *           only the global (process-wide) node.
+ * @returns the Node instance loaded as a RTT service in the given TaskContext,
+ * or falls back to the global (process-wide) Node loaded into the GlobalService.
+ * If none of both is loaded, the function returns nullptr.
+ */
+Node::shared_ptr getNodeService(RTT::TaskContext * tc = nullptr);
+
+/// Retrieve a rclcpp::Node::SharedPtr to be used for the given TaskContext.
+/**
+ * @sa \ref getNodeService()
+ * @returns getNodeService(tc) ? getNodeService(tc)->node() : nullptr
+ */
+rclcpp::Node::SharedPtr getNode(RTT::TaskContext * tc = nullptr);
 
 }  // namespace rtt_ros2_node
 

--- a/rtt_ros2_node/src/rtt_ros2_node.cpp
+++ b/rtt_ros2_node/src/rtt_ros2_node.cpp
@@ -74,6 +74,12 @@ Node::Node(
     !node_name.empty() ? node_name : default_node_name_from_owner(owner),
     namespace_, options);
 
+  this->addOperation("spin", &Node::spin, this)
+  .doc("Start a single or multi-threaded spinner for this node")
+  .arg("number_of_threads", "The number of spinner threads (0 = hardware concurrency)");
+  this->addOperation("cancel", &Node::cancel, this)
+  .doc("Cancel all operations and stop the spinner threads for this node");
+
   // eventually start a spinner
   const auto number_of_threads =
     node_->declare_parameter<int>("spinner_threads", 0);  // 0 = hardware concurrency


### PR DESCRIPTION
... to retrieve a `rtt_ros2_node::Node::shared_ptr` or rclcpp::Node::SharedPtr instance to be used for the given `TaskContext`, respectively.

Those methods will be reused in `rtt_ros2_params`, `rtt_ros2_topics` etc., whenever a `rclcpp::Node::SharedPtr` instance is needed for a specific `TaskContext` instance.

Additionally, the methods `spin()` and `cancel()` are added as operations to the `Node` service interface. This was an oversight in the initial version added in https://github.com/orocos/rtt_ros2_integration/commit/97e23c860deb456bbdb2411226fd440cd989f129.