### PR TITLE
rtt_ros2_idl: use rtt_ros2_@(pkg_name) as the namespace for the generated TypekitPlugin class

### DIFF
--- a/rtt_ros2_idl/src/rtt_ros2_idl/resource/typekit_plugin.cpp.em
+++ b/rtt_ros2_idl/src/rtt_ros2_idl/resource/typekit_plugin.cpp.em
@@ -25,7 +25,7 @@ extern template class rtt_ros2_idl::RosIntrospectionTypeInfo<@(pkg_name)::action
 extern template class rtt_ros2_idl::RosIntrospectionTypeInfo<@(pkg_name)::action::@(action_name)::Result>;
 @[end for]@
 
-namespace rtt_@(pkg_name) {
+namespace rtt_ros2_@(pkg_name) {
 
 class TypekitPlugin : public RTT::types::TypekitPlugin
 {
@@ -61,6 +61,6 @@ public:
   }
 };
 
-}  // namespace rtt_@(pkg_name)
+}  // namespace rtt_ros2_@(pkg_name)
 
-ORO_TYPEKIT_PLUGIN(rtt_@(pkg_name)::TypekitPlugin)
+ORO_TYPEKIT_PLUGIN(rtt_ros2_@(pkg_name)::TypekitPlugin)


### PR DESCRIPTION
... for consistency with the respective package names in https://github.com/orocos/rtt_ros2_common_interfaces
and other typekit packages.

Not so important, because the `rtt_ros2_@(pkg_name)::TypekitPlugin` class is only instantiated by the RTT plugin loader though a factory generated by the `ORO_TYPEKIT_PLUGIN()` macro and not supposed to be used directly. The class could even be declared with [hidden visibility](https://gcc.gnu.org/wiki/Visibility) (e.g. with [`RTT_HIDE`](https://github.com/orocos-toolchain/rtt/blob/600102e8be9c81905b20930e32d43b28244ab173/rtt/rtt-config.h.in#L113)) or in an anonymous namespace.

`rtt_@(pkg_name)` was the default name for typekit packages in [rtt_ros_integration/typekits](https://github.com/orocos/rtt_ros_integration/tree/toolchain-2.9/typekits).