### PR TITLE
.travis.yml: do not trigger a build for pushed branches other than master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ cache:
 git:
   quiet: true # optional, silences the cloning of the target repository
 
+# limit automatic builds to certain branches (and pull requests)
+branches:
+  only:
+  - master
+
 # configure the build environment(s)
 # https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#variables-you-can-configure
 env:


### PR DESCRIPTION
Builds for testing pull requests are not excluded, but it avoids [‘Double builds’ on pull requests](https://docs.travis-ci.com/user/pull-requests#double-builds-on-pull-requests).

The same configuration has been applied to [rtt_ros_integration](https://github.com/orocos/rtt_ros_integration) (since https://github.com/orocos/rtt_ros_integration/commit/96ae8f83ab3e1ee80b8f09f51abd644abc62b2e6) and [rtt_ros2_common_interfaces](https://github.com/orocos/rtt_ros2_common_interfaces) (since https://github.com/orocos/rtt_ros2_common_interfaces/pull/4).