### PR TITLE
Add a script and template to create new typekit packages

### DIFF
--- a/rtt_ros2_interfaces/CMakeLists.txt
+++ b/rtt_ros2_interfaces/CMakeLists.txt
@@ -6,6 +6,15 @@ find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_idl REQUIRED)
 find_package(rtt_ros2_topics REQUIRED)
 
+# install typekit package template and create_typekit_package script
+install(
+  DIRECTORY template
+  DESTINATION share/${PROJECT_NAME}/
+)
+install(PROGRAMS scripts/create_typekit_package
+  DESTINATION lib/${PROJECT_NAME}/
+)
+
 # linters
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rtt_ros2_interfaces/package.xml
+++ b/rtt_ros2_interfaces/package.xml
@@ -15,6 +15,10 @@
   <depend>rtt_ros2_idl</depend>
   <depend>rtt_ros2_topics</depend>
 
+  <!-- for create_typekit_package script -->
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rosidl_cmake</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rtt_ros2_interfaces/scripts/create_typekit_package
+++ b/rtt_ros2_interfaces/scripts/create_typekit_package
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright 2020 Intermodalics BVBA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from pathlib import Path
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+from rosidl_cmake import expand_template
+
+TEMPLATE_DIR = Path(get_package_share_directory('rtt_ros2_interfaces')) / 'template'
+AVAILABLE_TRANSPORTS = (
+  'ros',
+)
+DEFAULT_TRANSPORTS = ['ros']
+
+
+def create_typekit_package(package, transports, **kwargs):
+    # Create package directory
+    if kwargs.get('destination_directory', None):
+        destination_directory = Path(kwargs['destination_directory'])
+    else:
+        destination_directory = Path.cwd()
+    destination_directory = destination_directory / f"rtt_ros2_{package}"
+    destination_directory.mkdir(parents=True)
+
+    # Generate files
+    data = kwargs
+    data.update({
+        'package': package,
+        'transports': transports,
+    })
+    for file in ('package.xml', 'CMakeLists.txt'):
+        expand_template(
+            file,
+            data=data,
+            output_file=(destination_directory / file),
+            template_basepath=TEMPLATE_DIR)
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Generate an RTT typekit package.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        'package', metavar='PACKAGE',
+        help='The name of the interface package')
+
+    parser.add_argument(
+        '--destination-directory', '-d',
+        default='.',
+        help='Directory where to create the package directory (not including the package name)')
+
+    plugins_group = parser.add_argument_group('plugin options')
+    plugins_group.add_argument(
+        '--transports', nargs='+', metavar='TRANSPORT', choices=AVAILABLE_TRANSPORTS,
+        default=DEFAULT_TRANSPORTS,
+        help='Whether to add a ROS transport plugin (available: ' +
+             ' '.join(AVAILABLE_TRANSPORTS) + ')')
+    plugins_group.add_argument(
+        '--no-transport', action='store_const', dest='transports', const=[],
+        default=argparse.SUPPRESS,
+        help='Create a pure typekit package (no transport plugins)')
+
+    package_xml_group = parser.add_argument_group('package.xml options')
+    package_xml_group.add_argument(
+        '--description',
+        default=argparse.SUPPRESS,
+        help='The description given in the package.xml')
+    package_xml_group.add_argument(
+        '--license',
+        default='Apache License 2.0',
+        help='The license attached to this package')
+    package_xml_group.add_argument(
+        '--maintainer-email',
+        default='orocos-dev@orocos.org',
+        help='email address of the maintainer of this package')
+    package_xml_group.add_argument(
+        '--maintainer-name',
+        default='Orocos Developers',
+        help='name of the maintainer of this package')
+
+    args = parser.parse_args(argv)
+    return create_typekit_package(**vars(args))
+
+
+if __name__ == '__main__':
+    main()

--- a/rtt_ros2_interfaces/template/CMakeLists.txt
+++ b/rtt_ros2_interfaces/template/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.5)
+project(rtt_ros2_@(package))
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#   add_compile_options(-Wall -Wextra -Wpedantic)
+# endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+@[if transports]@
+find_package(rtt_ros2_interfaces REQUIRED)
+@[else]@
+find_package(rtt_ros2_idl REQUIRED)
+@[end if]@
+
+@[if transports]@
+rtt_ros2_generate_typekit_and_transports(@(package))
+@[else]@
+rtt_ros2_generate_typekit(@(package))
+@[end if]@
+
+# linters
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# must be called *after* the targets to check exported libraries etc.
+ament_package()
+
+# orocos_generate_package() is deprecated for ROS 2.
+# Prefer cmake target export and import instead, in combination with
+# ament_export_interfaces() or ament_export_targets() when building with
+# ament_cmake.
+orocos_generate_package(
+@[if transports]@
+  DEPENDS_TARGETS rtt_ros2_interfaces
+@[else]@
+  DEPENDS_TARGETS rtt_ros2_idl
+@[end if]@
+)

--- a/rtt_ros2_interfaces/template/package.xml
+++ b/rtt_ros2_interfaces/template/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rtt_ros2_@(package)</name>
+  <version>0.0.0</version>
+  <description>@(description or f"RTT typekit {'and transport plugins ' if transports else ''}for {package}")</description>
+  <maintainer email="@(maintainer_email or "orocos-dev@orocos.org")">@(maintainer_name or "Orocos Developers")</maintainer>
+  <license>@(license or "Apache License 2.0")</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>builtin_interfaces</depend>
+@[if transports]@
+  <depend>rtt_ros2_interfaces</depend>  <!-- typekit and transports -->
+@[else]@
+  <depend>rtt_ros2_idl</depend>  <!-- pure typekit -->
+@[end if]@
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
_Based on and to be merged after #10. Change target branch to `master` before!_

Usage:
```
$ ros2 run rtt_ros2_interfaces create_typekit_package --helpusage: create_typekit_package [-h]
                              [--destination-directory DESTINATION_DIRECTORY]
                              [--transports TRANSPORT [TRANSPORT ...]]
                              [--no-transport] [--description DESCRIPTION]
                              [--license LICENSE]
                              [--maintainer-email MAINTAINER_EMAIL]
                              [--maintainer-name MAINTAINER_NAME]
                              PACKAGE

Generate an RTT typekit package.

positional arguments:
  PACKAGE               The name of the interface package

optional arguments:
  -h, --help            show this help message and exit
  --destination-directory DESTINATION_DIRECTORY, -d DESTINATION_DIRECTORY
                        Directory where to create the package directory (not
                        including the package name) (default: .)

plugin options:
  --transports TRANSPORT [TRANSPORT ...]
                        Whether to add a ROS transport plugin (available: ros)
                        (default: ['ros'])
  --no-transport        Create a pure typekit package (no transport plugins)

package.xml options:
  --description DESCRIPTION
                        The description given in the package.xml
  --license LICENSE     The license attached to this package (default: Apache
                        License 2.0)
  --maintainer-email MAINTAINER_EMAIL
                        email address of the maintainer of this package
                        (default: orocos-dev@orocos.org)
  --maintainer-name MAINTAINER_NAME
                        name of the maintainer of this package (default:
                        Orocos Developers)
```