### PR TITLE
tests: declare all dependencies as <test_depend>

### DIFF
--- a/tests/rtt_ros2_idl_tests/package.xml
+++ b/tests/rtt_ros2_idl_tests/package.xml
@@ -11,13 +11,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2</depend>
-  <depend>rtt_ros2_idl</depend>
+  <test_depend>rtt_ros2</test_depend>
+  <test_depend>rtt_ros2_idl</test_depend>
+  <test_depend>rtt_ros2_test_msgs</test_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rtt_ros2_test_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tests/rtt_ros2_test_msgs/package.xml
+++ b/tests/rtt_ros2_test_msgs/package.xml
@@ -9,8 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2_interfaces</depend>
-  <depend>test_msgs</depend>
+  <test_depend>rtt_ros2_interfaces</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/tests/rtt_ros2_tests/package.xml
+++ b/tests/rtt_ros2_tests/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2</depend>
+  <test_depend>rtt_ros2</test_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/tests/rtt_ros2_topics_tests/package.xml
+++ b/tests/rtt_ros2_topics_tests/package.xml
@@ -11,13 +11,13 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rtt_ros2</depend>
-  <depend>rtt_ros2_topics</depend>
+  <test_depend>rtt_ros2</test_depend>
+  <test_depend>rtt_ros2_topics</test_depend>
+  <test_depend>rtt_ros2_test_msgs</test_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>rtt_ros2_test_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This patch reverts commit 6a1cbc69a884276e848d25408496fdac08042b7e (#11) and additionally changes many more dependencies in pure test packages from `<depend>` to `<test_depend>`.

Actually all dependencies are pure test dependencies and only required if `BUILD_TESTING` is not set to `OFF`.