### PR TITLE
Fix find ament_cmake in unit test packages

### DIFF
--- a/tests/rtt_ros2_idl_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_idl_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rtt_ros2_idl_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
+  find_package(ament_cmake REQUIRED)
   ament_package()
   return()
 endif()

--- a/tests/rtt_ros2_idl_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_idl_tests/CMakeLists.txt
@@ -4,8 +4,9 @@ project(rtt_ros2_idl_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
-  find_package(ament_cmake REQUIRED)
-  ament_package()
+  install(CODE
+    "message(STATUS \"Skipping installation of package ${PROJECT_NAME} because BUILD_TESTING is OFF.\")"
+  )
   return()
 endif()
 

--- a/tests/rtt_ros2_test_msgs/CMakeLists.txt
+++ b/tests/rtt_ros2_test_msgs/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rtt_ros2_test_msgs)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
+  find_package(ament_cmake REQUIRED)
   ament_package()
   return()
 endif()

--- a/tests/rtt_ros2_test_msgs/CMakeLists.txt
+++ b/tests/rtt_ros2_test_msgs/CMakeLists.txt
@@ -4,8 +4,9 @@ project(rtt_ros2_test_msgs)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
-  find_package(ament_cmake REQUIRED)
-  ament_package()
+  install(CODE
+    "message(STATUS \"Skipping installation of package ${PROJECT_NAME} because BUILD_TESTING is OFF.\")"
+  )
   return()
 endif()
 

--- a/tests/rtt_ros2_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rtt_ros2_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
+  find_package(ament_cmake REQUIRED)
   ament_package()
   return()
 endif()

--- a/tests/rtt_ros2_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_tests/CMakeLists.txt
@@ -4,8 +4,9 @@ project(rtt_ros2_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
-  find_package(ament_cmake REQUIRED)
-  ament_package()
+  install(CODE
+    "message(STATUS \"Skipping installation of package ${PROJECT_NAME} because BUILD_TESTING is OFF.\")"
+  )
   return()
 endif()
 

--- a/tests/rtt_ros2_topics_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_topics_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rtt_ros2_topics_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
+  find_package(ament_cmake REQUIRED)
   ament_package()
   return()
 endif()

--- a/tests/rtt_ros2_topics_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_topics_tests/CMakeLists.txt
@@ -4,8 +4,9 @@ project(rtt_ros2_topics_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
-  find_package(ament_cmake REQUIRED)
-  ament_package()
+  install(CODE
+    "message(STATUS \"Skipping installation of package ${PROJECT_NAME} because BUILD_TESTING is OFF.\")"
+  )
   return()
 endif()
 


### PR DESCRIPTION

# Description

The test packages return immediately to skip compiling when not building for testing. To avoid `cmake` to return with errors, the call `ament_package()` precedes `return()`. The problem is that `ament_cmake` package should be found first.

This PR fixes that problem.
