### PR TITLE
rtt_ros2_interfaces: rename rtt_ros2_generate_typekit_and_transports() cmake macro to rtt_ros2_generate_interfaces_plugins()

### DIFF
--- a/rtt_ros2_interfaces/CMakeLists.txt
+++ b/rtt_ros2_interfaces/CMakeLists.txt
@@ -28,7 +28,7 @@ ament_export_dependencies(rtt_ros2_topics)
 # must be called *after* the targets to check exported libraries etc.
 ament_package(
   CONFIG_EXTRAS
-    cmake/${PROJECT_NAME}-generate_typekit_and_transports.cmake
+    cmake/${PROJECT_NAME}-generate_interfaces_plugins.cmake
 )
 
 # orocos_generate_package() is deprecated for ROS 2.

--- a/rtt_ros2_interfaces/cmake/rtt_ros2_interfaces-generate_interfaces_plugins.cmake
+++ b/rtt_ros2_interfaces/cmake/rtt_ros2_interfaces-generate_interfaces_plugins.cmake
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 #
-# Generate an RTT typekit, ROS transport and ROS service plugins for all messages, services and
-# actions defined in a ROS interface packages.
+# Generate an RTT typekit, ROS transport and ROS service plugins for all
+# messages, services and actions defined in a ROS interface packages.
 #
 macro(rtt_ros2_generate_interfaces_plugins _package)
   rtt_ros2_generate_typekit(${_package} ${ARGN})

--- a/rtt_ros2_interfaces/cmake/rtt_ros2_interfaces-generate_typekit_and_transports.cmake
+++ b/rtt_ros2_interfaces/cmake/rtt_ros2_interfaces-generate_typekit_and_transports.cmake
@@ -13,9 +13,17 @@
 # limitations under the License.
 
 #
-# Generate an RTT typekit and ROS transport plugin for ROS interface packages.
+# Generate an RTT typekit, ROS transport and ROS service plugins for all messages, services and
+# actions defined in a ROS interface packages.
 #
-macro(rtt_ros2_generate_typekit_and_transports _package)
+macro(rtt_ros2_generate_interfaces_plugins _package)
   rtt_ros2_generate_typekit(${_package} ${ARGN})
   rtt_ros2_generate_ros_transport(${_package} ${ARGN})
+endmacro()
+
+macro(rtt_ros2_generate_typekit_and_transports _package)
+  message(WARNING
+    "rtt_ros2_generate_typekit_and_transports() is deprecated. Please use macro"
+    "rtt_ros2_generate_interfaces_plugins() instead.")
+    rtt_ros2_generate_interfaces_plugins(${_package} ${ARGN})
 endmacro()

--- a/rtt_ros2_interfaces/template/CMakeLists.txt
+++ b/rtt_ros2_interfaces/template/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(rtt_ros2_idl REQUIRED)
 @[end if]@
 
 @[if transports]@
-rtt_ros2_generate_typekit_and_transports(@(package))
+rtt_ros2_generate_interfaces_plugins(@(package))
 @[else]@
 rtt_ros2_generate_typekit(@(package))
 @[end if]@

--- a/tests/rtt_ros2_test_msgs/CMakeLists.txt
+++ b/tests/rtt_ros2_test_msgs/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
-rtt_ros2_generate_typekit_and_transports(test_msgs)
+rtt_ros2_generate_interfaces_plugins(test_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/typekits/rtt_ros2_action_msgs/CMakeLists.txt
+++ b/typekits/rtt_ros2_action_msgs/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
-rtt_ros2_generate_typekit_and_transports(action_msgs)
+rtt_ros2_generate_interfaces_plugins(action_msgs)
 
 # linters
 if(BUILD_TESTING)

--- a/typekits/rtt_ros2_unique_identifier_msgs/CMakeLists.txt
+++ b/typekits/rtt_ros2_unique_identifier_msgs/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rtt_ros2_interfaces REQUIRED)
 
-rtt_ros2_generate_typekit_and_transports(unique_identifier_msgs)
+rtt_ros2_generate_interfaces_plugins(unique_identifier_msgs)
 
 # linters
 if(BUILD_TESTING)


### PR DESCRIPTION
The previous name was too specific. The macro will be extended to support ROS service plugins soon in package `rtt_ros2_services`, so the name of the macro would have been outdated again.

`rtt_ros2_generate_interfaces_plugins()` is meant to generate whatever plugin library type is supported by rtt_ros2_integration for the given ROS 2 interfaces package (typekit, ROS transport, service plugin, action support, ...).