### PR TITLE
rtt_ros2_topics: update RTT plugin name to "rostopic" to match "rosnode" and "rosparam"

### DIFF
--- a/rtt_ros2_topics/src/rtt_ros2_topics_service.cpp
+++ b/rtt_ros2_topics/src/rtt_ros2_topics_service.cpp
@@ -67,7 +67,7 @@ bool loadRTTPlugin(RTT::TaskContext * tc)
   loadGlobalROSService();
   return true;
 }
-std::string getRTTPluginName() {return "ros2-topics";}
+std::string getRTTPluginName() {return "rostopic";}
 std::string getRTTTargetName() {return OROCOS_TARGET_NAME;}
 }
 


### PR DESCRIPTION
This PR concludes on #18 (_Reconsider service names_) (closes #18):

- Package `rtt_ros2_topics` provides the service plugin "rostopic" now. At the moment the `rostopic` service cannot be loaded into a component. It only provides additional operations in the global service `ros`, which is why the string returned by `getRTTPluginName()` does not really matter. That might change in the future for addressing #16.

- The service and plugin name provided by package `rtt_ros2_params` was changed to `"rosparam"` in https://github.com/orocos/rtt_ros2_integration/pull/7/commits/b62ddea9fa6bda594316262a093a113d3bc80424 after a PR review of #7.

- The service and plugin name provided by package `rtt_ros2_node` was already changed to `"rosnode"` in https://github.com/orocos/rtt_ros2_integration/pull/7/commits/be27f6ea217dca63e5952fe09dbe6e43461c4ab4 and https://github.com/orocos/rtt_ros2_integration/pull/7/commits/f6e9fe57fcd250323a6d56e868fdd39b4810174f (#7).