### PR TITLE
rtt_ros2_params_tests: fix build with BUILD_TESTING set to OFF

### DIFF
--- a/tests/rtt_ros2_params_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_params_tests/CMakeLists.txt
@@ -4,7 +4,9 @@ project(rtt_ros2_params_tests)
 # Skip building this package if BUILD_TESTING is OFF
 option(BUILD_TESTING "Build the testing tree." ON)
 if(NOT BUILD_TESTING)
-  ament_package()
+  install(CODE
+    "message(STATUS \"Skipping installation of package ${PROJECT_NAME} because BUILD_TESTING is OFF.\")"
+  )
   return()
 endif()
 


### PR DESCRIPTION
Applies 50199c0eb97d57859c29deeba73e97bdfae09032 (https://github.com/orocos/rtt_ros2_integration/pull/20) to package `rtt_ros2_params_tests` added in https://github.com/orocos/rtt_ros2_integration/pull/7:

`ament_package()` is not available before `find_package(ament_cmake)` has been called. Instead, we do not invoke `ament_package()` and install nothing if `BUILD_TESTING` is `OFF`.

This bug affects Docker image builds that include `rtt_ros2_integration` and pass `-DBUILD_TESTING=OFF` (https://github.com/orocos/orocos-docker-images/pull/3).