### PR TITLE
rtt_ros2: install environment hook to set PKG_CONFIG_PATH

### DIFF
--- a/rtt_ros2/CMakeLists.txt
+++ b/rtt_ros2/CMakeLists.txt
@@ -96,12 +96,17 @@ endif()
 # for recursive dependencies
 ament_index_register_resource("rtt_ros2_plugin_depends" CONTENT "")
 
-# register environment hook to prepend to RTT_COMPONENT_PATH
+# register environment hooks to prepend to RTT_COMPONENT_PATH and PKG_CONFIG_PATH
 set(
   AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_rtt_component_path
   "prepend-non-duplicate;RTT_COMPONENT_PATH;lib/orocos"
 )
 ament_environment_hooks(env_hook/rtt_component_path.sh.in)
+set(
+  AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_pkg_config_path
+  "prepend-non-duplicate;PKG_CONFIG_PATH;lib/pkgconfig"
+)
+ament_environment_hooks(env_hook/pkg_config_path.sh.in)
 
 # must be called *after* the targets to check exported libraries etc.
 ament_package(

--- a/rtt_ros2/env_hook/pkg_config_path.sh.in
+++ b/rtt_ros2/env_hook/pkg_config_path.sh.in
@@ -1,0 +1,1 @@
+ament_prepend_unique_value PKG_CONFIG_PATH "$AMENT_CURRENT_PREFIX/lib/pkgconfig"


### PR DESCRIPTION
This is required for `orocos_generate_package()` and `orocos_find_package()` to work properly if `rtt_ros2_integration` is not installed in the same install-space as Orocos RTT.

Note that `orocos_generate_package(DEPENDS ...)` does not work anymore in ROS 2. Orocos packages cannot export non-Orocos ROS dependencies using this macro and underlying pkg-config (e.g. interface packages, `rclcpp` etc.). That is why `orocos_generate_package()` and `orocos_use_package()` is discouraged, in favor of just plain modern CMake and `ament_cmake`'s macros to support target ex- and import:

```cmake
# orocos_generate_package() is deprecated for ROS 2.
# Prefer cmake target export and import instead, in combination with
# ament_export_interfaces() or ament_export_targets() when building with
# ament_cmake.
orocos_generate_package()
```

Maybe we should remove the `orocos_generate_package()` calls completely. `orocos_use_package()` will not work anyway in most cases.