### PR TITLE
rtt_ros2_params: add service requester in header rosparam.hpp

### DIFF
--- a/rtt_ros2_params/include/orocos/rtt_ros2_params/rosparam.hpp
+++ b/rtt_ros2_params/include/orocos/rtt_ros2_params/rosparam.hpp
@@ -30,7 +30,7 @@ class RosParam : public RTT::ServiceRequester
 public:
   typedef boost::shared_ptr<RosParam> shared_ptr;
 
-  RosParam(RTT::TaskContext * owner)
+  explicit RosParam(RTT::TaskContext * owner)
   : RTT::ServiceRequester("rosparam", owner),
     getParameter("getParameter"),
     setParameter("setParameter"),

--- a/rtt_ros2_params/include/orocos/rtt_ros2_params/rosparam.hpp
+++ b/rtt_ros2_params/include/orocos/rtt_ros2_params/rosparam.hpp
@@ -1,0 +1,77 @@
+// Copyright 2020 Intermodalics BVBA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OROCOS__RTT_ROS2_PARAMS__ROSPARAM_HPP_
+#define OROCOS__RTT_ROS2_PARAMS__ROSPARAM_HPP_
+
+#include <string>
+
+#include "rtt/OperationCaller.hpp"
+#include "rtt/ServiceRequester.hpp"
+
+#include "rclcpp/parameter_value.hpp"
+
+namespace rtt_ros2_params
+{
+
+class RosParam : public RTT::ServiceRequester
+{
+public:
+  typedef boost::shared_ptr<RosParam> shared_ptr;
+
+  RosParam(RTT::TaskContext * owner)
+  : RTT::ServiceRequester("rosparam", owner),
+    getParameter("getParameter"),
+    setParameter("setParameter"),
+    setOrDeclareParameter("setOrDeclareParameter"),
+    loadProperty("loadProperty"),
+    storeProperty("storeProperty")
+  {
+    this->addOperationCaller(getParameter);
+    this->addOperationCaller(setParameter);
+    this->addOperationCaller(setOrDeclareParameter);
+
+    // Operations loadProperty and storeProperty are only available if the requester is connected
+    // to a service loaded into a component. They are added dynamically in connectTo().
+  }
+  virtual ~RosParam() = default;
+
+  bool connectTo(RTT::Service::shared_ptr sp) override
+  {
+    const bool has_owner = (sp->getOwner() != nullptr);
+    if (has_owner) {
+      this->addOperationCaller(loadProperty);
+      this->addOperationCaller(storeProperty);
+    }
+    return RTT::ServiceRequester::connectTo(sp);
+  }
+
+  RTT::OperationCaller<rclcpp::ParameterValue(const std::string & name)> getParameter;
+  RTT::OperationCaller<bool(
+      const std::string & name,
+      const rclcpp::ParameterValue & value)> setParameter;
+  RTT::OperationCaller<bool(
+      const std::string & name,
+      const rclcpp::ParameterValue & value)> setOrDeclareParameter;
+  RTT::OperationCaller<bool(
+      const std::string & property_name,
+      const std::string & param_name)> loadProperty;
+  RTT::OperationCaller<bool(
+      const std::string & property_name,
+      const std::string & param_name)> storeProperty;
+};
+
+}  // namespace rtt_ros2_params
+
+#endif  // OROCOS__RTT_ROS2_PARAMS__ROSPARAM_HPP_

--- a/rtt_ros2_params/include/orocos/rtt_ros2_params/rtt_ros2_params.hpp
+++ b/rtt_ros2_params/include/orocos/rtt_ros2_params/rtt_ros2_params.hpp
@@ -49,9 +49,6 @@ protected:
   bool storeProperty(
     const std::string & property_name,
     const std::string & param_name);
-
-private:
-  RTT::TaskContext * owner_;
 };  // class Params
 
 }  // namespace rtt_ros2_params

--- a/rtt_ros2_params/src/rtt_ros2_params.cpp
+++ b/rtt_ros2_params/src/rtt_ros2_params.cpp
@@ -61,6 +61,11 @@ Params::Params(RTT::TaskContext * owner)
   .arg("name", "Name of the parameter to set")
   .arg("value", "The value of the parameter to set");
 
+  addOperation("setOrDeclareParameter", &Params::setOrDeclareParameter, this, RTT::ClientThread)
+  .doc("Sets a parameter to the node parameter server and eventually declares it")
+  .arg("name", "Name of the parameter to set")
+  .arg("value", "The value of the parameter to set");
+
   if (nullptr != owner) {
     addOperation("loadProperty", &Params::loadProperty, this, RTT::ClientThread)
     .doc("Loads a parameter from the node parameter server into a Property")

--- a/tests/rtt_ros2_params_tests/CMakeLists.txt
+++ b/tests/rtt_ros2_params_tests/CMakeLists.txt
@@ -58,5 +58,5 @@ orocos_configure_executable(test_ros_params)
 target_link_libraries(test_ros_params
   rtt_ros2::rtt_ros2
   rtt_ros2_node::rtt_ros2_node
-  rtt_ros2_params::rtt_ros2_params
+#  rtt_ros2_params::rtt_ros2_params  # not needed thanks to RosParam service requester
 )


### PR DESCRIPTION
The header-only service requester `RosParam` allows to use the `rtt_ros2_params` functionality from other C++ code without the need to link to `rtt_ros2_params` targets explicitly. The `ServiceRequester` is bound to the `rosparam` service at run-time.

See the updated unit test for an example on how to use 

Also fixes two more bugs from #7:
- The member variable `Params::owner_` was unused and not initialized. The base class `RTT::Service` already keeps track of the owner (`TaskContext`) itself.
- Operation `setOrDeclareParameter` was not registered in the constructor and hence the new `RosParam` service requester failed to connect it.