### PR TITLE
rtt_ros2_node: fix default NodeOptions with allow_undeclared_parameters

### DIFF
--- a/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
+++ b/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
@@ -26,6 +26,9 @@
 namespace rtt_ros2_node
 {
 
+/// Return the default rclcpp::NodeOptions to be used within RTT and rtt_ros2_integration.
+rclcpp::NodeOptions getDefaultNodeOptions();
+
 /// Wrap a rclcpp::Node instance in an RTT::Service.
 struct Node : public RTT::Service
 {
@@ -34,16 +37,16 @@ public:
 
   explicit Node(RTT::TaskContext * owner = nullptr);
   Node(
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
+    const rclcpp::NodeOptions & options = getDefaultNodeOptions(),
     RTT::TaskContext * owner = nullptr);
   Node(
     const std::string & node_name,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
+    const rclcpp::NodeOptions & options = getDefaultNodeOptions(),
     RTT::TaskContext * owner = nullptr);
   Node(
     const std::string & node_name,
     const std::string & namespace_,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
+    const rclcpp::NodeOptions & options = getDefaultNodeOptions(),
     RTT::TaskContext * owner = nullptr);
   virtual ~Node();
 

--- a/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
+++ b/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
@@ -45,7 +45,7 @@ public:
     RTT::TaskContext * owner = nullptr);
   Node(
     const std::string & node_name,
-    const std::string & namespace_,
+    const std::string & _namespace,
     const rclcpp::NodeOptions & options = getDefaultNodeOptions(),
     RTT::TaskContext * owner = nullptr);
   virtual ~Node();

--- a/rtt_ros2_node/src/rtt_ros2_node.cpp
+++ b/rtt_ros2_node/src/rtt_ros2_node.cpp
@@ -42,10 +42,16 @@ std::string default_node_name_from_owner(RTT::TaskContext * owner)
 
 }  // namespace
 
+rclcpp::NodeOptions getDefaultNodeOptions()
+{
+  return rclcpp::NodeOptions()
+         .allow_undeclared_parameters(true);
+}
+
 Node::Node(
   RTT::TaskContext * owner)
 : Node(default_node_name_from_owner(owner), {},
-    rclcpp::NodeOptions().allow_undeclared_parameters(true), owner)
+    getDefaultNodeOptions(), owner)
 {
 }
 

--- a/rtt_ros2_node/src/rtt_ros2_node.cpp
+++ b/rtt_ros2_node/src/rtt_ros2_node.cpp
@@ -72,14 +72,14 @@ Node::Node(
 
 Node::Node(
   const std::string & node_name,
-  const std::string & namespace_,
+  const std::string & _namespace,
   const rclcpp::NodeOptions & options,
   RTT::TaskContext * owner)
 : RTT::Service("rosnode", owner)
 {
   node_ = std::make_shared<rclcpp::Node>(
     !node_name.empty() ? node_name : default_node_name_from_owner(owner),
-    namespace_, options);
+    _namespace, options);
 
   this->addOperation("spin", &Node::spin, this)
   .doc("Start a single or multi-threaded spinner for this node")

--- a/rtt_ros2_node/src/rtt_ros2_node_service.cpp
+++ b/rtt_ros2_node/src/rtt_ros2_node_service.cpp
@@ -52,18 +52,18 @@ static bool create_named_node_with_namespace(
   const std::string & node_name,
   const std::string & namespace_)
 {
-  return create_named_node_with_options(node_name, namespace_, rclcpp::NodeOptions());
+  return create_named_node_with_options(node_name, namespace_, getDefaultNodeOptions());
 }
 
 static bool create_named_node(
   const std::string & node_name)
 {
-  return create_named_node_with_options(node_name, {}, rclcpp::NodeOptions());
+  return create_named_node_with_options(node_name, {}, getDefaultNodeOptions());
 }
 
 static bool create_node()
 {
-  return create_named_node_with_options({}, {}, rclcpp::NodeOptions());
+  return create_named_node_with_options({}, {}, getDefaultNodeOptions());
 }
 
 static void loadGlobalROSService()

--- a/tests/rtt_ros2_params_tests/test/test_ros_params.cpp
+++ b/tests/rtt_ros2_params_tests/test/test_ros_params.cpp
@@ -83,8 +83,9 @@ TEST_F(TestRosParams, TestGlobalNodeParams)
   ASSERT_TRUE(rosparam.connectTo(global_params));
 
   // Check set non-existent parameters
-  EXPECT_FALSE(
-    rosparam.setParameter("fake_parameter", rclcpp::ParameterValue(42)));
+  // True because rosnode is created with allow_undeclared_parameters(true)
+  EXPECT_TRUE(
+    rosparam.setParameter("new_fake_parameter", rclcpp::ParameterValue(42)));
 
   // Check get non-existent parameters
   EXPECT_EQ(


### PR DESCRIPTION
... for all possible ways to construct an `rtt_ros2_node::Node` instance. The default options are defined differently than in `rclcpp` to allow storing properties as ROS parameters without the need to declare them first (since #7). But only the constructor overload `Node(RTT::TaskContext * owner)` was modified in https://github.com/orocos/rtt_ros2_integration/pull/7/commits/8caa834ffcd63ab90b1dfad285e38e7f08074565, not the three others with default arguments defined in the header.

Still a crippled solution, because `NodeOptions` is also a type provided by `rtt_ros2_rclcpp_typekit` and there `allow_undeclared_parameters` would be `false` by default. A subclass with another default value would introduce a new type, with another, imcompatible typeid. So maybe the best option is to revert https://github.com/orocos/rtt_ros2_integration/pull/7/commits/8caa834ffcd63ab90b1dfad285e38e7f08074565 instead, and to declare the ROS parameter explicitly in `Params::storeProperty()`? For `Params::setParameter()` we already have an alternative operation `setOrDeclareParameter()`.