### PR TITLE
added dependency to build first the ros package

### DIFF
--- a/rtt_ros2_interfaces/template/package.xml
+++ b/rtt_ros2_interfaces/template/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>@(package)</depend>
 @[if transports]@
   <depend>rtt_ros2_interfaces</depend>  <!-- typekit and transports -->
 @[else]@


### PR DESCRIPTION
By making the dependency explicit, it is enforced that the ROS interface package is built before the RTT typekit.
In most cases, the problem goes unnoticed if the ROS package is already built. I noticed when I clean up the built and install directories and rebuilt all.