### PR TITLE
rtt_ros2_params:  add declareParameter operation

### DIFF
--- a/rtt_ros2_params/include/orocos/rtt_ros2_params/rosparam.hpp
+++ b/rtt_ros2_params/include/orocos/rtt_ros2_params/rosparam.hpp
@@ -34,12 +34,14 @@ public:
   : RTT::ServiceRequester("rosparam", owner),
     getParameter("getParameter"),
     setParameter("setParameter"),
+    declareParameter("declareParameter"),
     setOrDeclareParameter("setOrDeclareParameter"),
     loadProperty("loadProperty"),
     storeProperty("storeProperty")
   {
     this->addOperationCaller(getParameter);
     this->addOperationCaller(setParameter);
+    this->addOperationCaller(declareParameter);
     this->addOperationCaller(setOrDeclareParameter);
 
     // Operations loadProperty and storeProperty are only available if the requester is connected
@@ -61,6 +63,9 @@ public:
   RTT::OperationCaller<bool(
       const std::string & name,
       const rclcpp::ParameterValue & value)> setParameter;
+  RTT::OperationCaller<bool(
+      const std::string & name,
+      const rclcpp::ParameterValue & default_value)> declareParameter;
   RTT::OperationCaller<bool(
       const std::string & name,
       const rclcpp::ParameterValue & value)> setOrDeclareParameter;

--- a/rtt_ros2_params/include/orocos/rtt_ros2_params/rtt_ros2_params_service.hpp
+++ b/rtt_ros2_params/include/orocos/rtt_ros2_params/rtt_ros2_params_service.hpp
@@ -40,6 +40,9 @@ protected:
   bool setParameter(
     const std::string & name,
     const rclcpp::ParameterValue & value);
+  bool declareParameter(
+    const std::string & name,
+    const rclcpp::ParameterValue & default_value);
   bool setOrDeclareParameter(
     const std::string & name,
     const rclcpp::ParameterValue & value);


### PR DESCRIPTION
Add declare_parameter with optional default value. Since setOrDeclareParameter operation override the parameter value if it was declared, it's necessary if ROS parameter are set externally at launch. 