### PR TITLE
fix api differences on executors in ROS2 humble

### DIFF
--- a/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
+++ b/rtt_ros2_node/include/orocos/rtt_ros2_node/rtt_ros2_node.hpp
@@ -51,14 +51,14 @@ public:
   virtual ~Node();
 
   rclcpp::Node::SharedPtr node() {return node_;}
-  rclcpp::executor::Executor::SharedPtr executor() {return executor_;}
+  rclcpp::Executor::Executor::SharedPtr executor() {return executor_;}
 
   void spin(unsigned int number_of_threads = 1);
   void cancel();
 
 protected:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::executor::Executor::SharedPtr executor_;
+  rclcpp::Executor::Executor::SharedPtr executor_;
   std::thread thread_;
 };
 

--- a/rtt_ros2_node/src/rtt_ros2_node.cpp
+++ b/rtt_ros2_node/src/rtt_ros2_node.cpp
@@ -104,7 +104,7 @@ void Node::spin(unsigned int number_of_threads)
 {
   cancel();
   const auto executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(
-    rclcpp::executor::ExecutorArgs(),
+    rclcpp::ExecutorOptions(),
     number_of_threads
   );
   executor->add_node(node_);

--- a/rtt_ros2_node/src/rtt_ros2_node_service.cpp
+++ b/rtt_ros2_node/src/rtt_ros2_node_service.cpp
@@ -74,7 +74,7 @@ static void loadGlobalROSService()
 
   // Call rclcpp::init()
   rclcpp::InitOptions init_options;
-  init_options.shutdown_on_sigint = false;
+  init_options.shutdown_on_signal = false;
   RTT::log(RTT::Info) <<
     "Initializing ROS context with " << __os_main_argc() << " command-line arguments." <<
     RTT::endlog();


### PR DESCRIPTION

# Fix API changes in Humble

## Description

This patch fixes some changes on deprecated API `rclcpp::executor` by the workspace `rclcpp::Executor` and the options passed to the executor.